### PR TITLE
permit '%r' and '%R' to specify user@domain via %r@%R for envelope rcpt,...

### DIFF
--- a/smtpd/lka_session.c
+++ b/smtpd/lka_session.c
@@ -503,6 +503,12 @@ lka_expand_format(char *buf, size_t len, const struct envelope *ep)
 			case 'd':
 				string = ep->dest.domain;
 				break;
+			case 'r':
+				string = ep->rcpt.user;
+				break;
+			case 'R':
+				string = ep->rcpt.domain;
+				break;
 			default:
 				goto copy;
 			}


### PR DESCRIPTION
... otherwise this is not available to a mda
