### PR TITLE
Unix socket support for LMTP

### DIFF
--- a/smtpd/delivery_lmtp.c
+++ b/smtpd/delivery_lmtp.c
@@ -22,6 +22,7 @@
 #include <sys/queue.h>
 #include <sys/tree.h>
 #include <sys/socket.h>
+#include <sys/un.h>
 
 #include <ctype.h>
 #include <err.h>
@@ -42,6 +43,7 @@
 static void delivery_lmtp_open(struct deliver *);
 
 static int inet_socket(char *);
+static int unix_socket(char *);
 static char* lmtp_getline(FILE *);
 
 struct delivery_backend delivery_backend_lmtp = {
@@ -100,6 +102,30 @@ inet_socket (char *address)
 	 return s;
 }
 
+static int
+unix_socket(char *path) {
+	 struct sockaddr_un addr;
+	 int s;
+
+	 bzero(&addr, sizeof(addr));
+
+	 if ((s = socket(PF_LOCAL, SOCK_STREAM, 0)) == -1) {
+		 warn("socket");
+		 return -1;
+	 }
+
+	 addr.sun_family = AF_UNIX;
+	 strlcpy(addr.sun_path, path, sizeof(addr.sun_path));
+
+	 if (connect(s, (struct sockaddr*) &addr, sizeof(addr)) == -1) {
+		 warn("connect");
+		 close(s);
+		 return -1;
+	 }
+
+	 return s;
+}
+
 static void
 delivery_lmtp_open(struct deliver *deliver)
 {
@@ -113,7 +139,10 @@ delivery_lmtp_open(struct deliver *deliver)
 
 	 fp = NULL;
 
-	 s = inet_socket(deliver->to);
+	 if (deliver->to[0] == '/')
+		 s = unix_socket(deliver->to);
+	 else
+		 s = inet_socket(deliver->to);
 
 	 if (s == -1 || (fp = fdopen(s, "r+")) == NULL)
 		 err(1, "couldn't establish connection");

--- a/smtpd/parse.y
+++ b/smtpd/parse.y
@@ -724,7 +724,7 @@ action		: userbase DELIVER TO MAILDIR			{
 		| userbase DELIVER TO LMTP STRING		{
 			rule->r_userbase = $1;
 			rule->r_action = A_LMTP;
-			if (strchr($5, ':')) {
+			if (strchr($5, ':') || $5[0] == '/') {
 				if (strlcpy(rule->r_value.buffer, $5,
 					sizeof(rule->r_value.buffer))
 					>= sizeof(rule->r_value.buffer))


### PR DESCRIPTION
Add unix socket support to LMTP delivery. Should work with the same config syntax with a path substituted for address e.g.:

```
accept from any for domain <domains> virtual <users> deliver to lmtp "/usr/local/var/run/dovecot/lmtp"
```

The string is considered Unix socket path if it starts with '/'.
