### PR TITLE
Correct some uninstall targets.

### DIFF
--- a/regress/bin/Makefile.am
+++ b/regress/bin/Makefile.am
@@ -24,4 +24,4 @@ install-exec-hook:
 	$(MKDIR_P) $(DESTDIR)$(bindir)
 
 uninstall-hook:
-	rm $(DESTDIR)$(bindir)/smtpscript(EXEEXT)
+	rm -f $(DESTDIR)$(bindir)/smtpscript$(EXEEXT)

--- a/smtpd/Makefile.am
+++ b/smtpd/Makefile.am
@@ -173,5 +173,6 @@ install-exec-hook: $(CONFIGFILES) $(MANPAGES)
 
 
 uninstall-hook:
-	rm 	$(DESTDIR)$(bindir)/newaliases$(EXEEXT) \
-		$(DESTDIR)$(sbindir)/makemap$(EXEEXT)
+	rm -f	$(DESTDIR)$(bindir)/newaliases$(EXEEXT) \
+		$(DESTDIR)$(sbindir)/makemap$(EXEEXT) \
+		$(DESTDIR)$(bindir)/mailq$(EXEEXT)


### PR DESCRIPTION
- Fix rm invocations of smtpscript, newaliases, and makemap.
- Add mailq to the list of programs removed during uninstall.

Note that prior to this, the uninstall process on my Debian system would fail.  Now it succeeds, and just leaves some thing behind (the man pages and /usr/loca/libexec/opensmtpd directory).
