### PR TITLE
Add files/directories to uninstall target.

### DIFF
--- a/contrib/libexec/mail.local/Makefile.am
+++ b/contrib/libexec/mail.local/Makefile.am
@@ -15,3 +15,6 @@ LDADD = 		$(LIBCOMPAT)
 # {v,}asprintf
 # setres{g,u}id
 CFLAGS +=		-D_GNU_SOURCE
+
+uninstall-hook:
+	rmdir	$(DESTDIR)$(libexecdir) 2> /dev/null || /bin/true

--- a/smtpd/Makefile.am
+++ b/smtpd/Makefile.am
@@ -176,3 +176,13 @@ uninstall-hook:
 	rm -f	$(DESTDIR)$(bindir)/newaliases$(EXEEXT) \
 		$(DESTDIR)$(sbindir)/makemap$(EXEEXT) \
 		$(DESTDIR)$(bindir)/mailq$(EXEEXT)
+	rm -f	$(DESTDIR)$(mandir)/$(mansubdir)5/aliases.5 \
+		$(DESTDIR)$(mandir)/$(mansubdir)5/forward.5 \
+		$(DESTDIR)$(mandir)/$(mansubdir)5/smtpd.conf.5 \
+		$(DESTDIR)$(mandir)/$(mansubdir)8/makemap.8 \
+		$(DESTDIR)$(mandir)/$(mansubdir)8/newaliases.8 \
+		$(DESTDIR)$(mandir)/$(mansubdir)8/smtpctl.8 \
+		$(DESTDIR)$(mandir)/$(mansubdir)8/smtpd.8
+	rmdir	$(DESTDIR)$(pkglibexecdir) \
+		$(DESTDIR)$(mandir)/$(mansubdir)5 \
+		$(DESTDIR)$(mandir)/$(mansubdir)8 2> /dev/null || /bin/true


### PR DESCRIPTION
- Remove man pages installed by opensmtpd.
- Remove directories created to contain installed files, only if empty.

This does _not_ deal with the configuration file, but I figured leaving it alone was sufficient for now.
