### PR TITLE
Don't export CVS control directory to tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*/CVS	export-ignore


### PR DESCRIPTION
Assuming you export your releases to tarballs using `git archive`, this will exclude CVS control directories from being exported. Example `git archive` invocation exporting the `opensmtpd-5.3p1` tag:

```
git archive --format=tar --prefix=opensmtpd-5.3p1/ opensmtpd-5.3p1 | gzip > opensmtpd-5.3p1.tar.gz
```
