### PR TITLE
Fix two typos in Gilles' copyright statement

### DIFF
--- a/smtpd/makemap.8
+++ b/smtpd/makemap.8
@@ -1,7 +1,7 @@
 .\"	$OpenBSD$
 .\"
 .\" Copyright (c) 2009 Jacek Masiulaniec <jacekm@openbsd.org>
-.\" Copyright (c) 2008-2009 Gilles Chechade <gilles@poolp.org>
+.\" Copyright (c) 2008-2009 Gilles Chehade <gilles@poolp.org>
 .\"
 .\" Permission to use, copy, modify, and distribute this software for any
 .\" purpose with or without fee is hereby granted, provided that the above

--- a/smtpd/newaliases.8
+++ b/smtpd/newaliases.8
@@ -1,7 +1,7 @@
 .\"	$OpenBSD$
 .\"
 .\" Copyright (c) 2009 Jacek Masiulaniec <jacekm@openbsd.org>
-.\" Copyright (c) 2008-2009 Gilles Chechade <gilles@poolp.org>
+.\" Copyright (c) 2008-2009 Gilles Chehade <gilles@poolp.org>
 .\"
 .\" Permission to use, copy, modify, and distribute this software for any
 .\" purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
Noticed some more typos when preparing the copyright file for Debian packaging.
