### PR TITLE
Make enqueuer mailname-aware

### DIFF
--- a/smtpd/enqueue.c
+++ b/smtpd/enqueue.c
@@ -220,8 +220,8 @@ enqueue(int argc, char *argv[])
 	argc -= optind;
 	argv += optind;
 
-	if (gethostname(host, sizeof(host)) == -1)
-		err(1, "gethostname");
+	if (getmailname(host, sizeof(host)) == -1)
+		err(1, "getmailname");
 	if ((pw = getpwuid(getuid())) == NULL)
 		user = "anonymous";
 	if (pw != NULL)

--- a/smtpd/parse.y
+++ b/smtpd/parse.y
@@ -110,7 +110,6 @@ int		 interface(const char *, int, const char *, const char *,
 void		 set_localaddrs(void);
 int		 delaytonum(char *);
 int		 is_if_in_group(const char *, const char *);
-int		 getmailname(char *, size_t);
 
 typedef struct {
 	union {
@@ -1950,73 +1949,4 @@ end:
 #else
 	return (0);
 #endif
-}
-
-int
-getmailname(char *hostname, size_t len)
-{
-	struct addrinfo	hints, *res = NULL;
-	FILE   *fp;
-	char   *buf, *lbuf = NULL;
-	size_t	buflen;
-	int	error;
-	int	ret = 0;
-
-	/* First, check if we have "/etc/mail/mailname" */
-	if ((fp = fopen(SMTPD_CONFDIR "/mailname", "r")) == NULL)
-		goto nomailname;
-
-	if ((buf = fgetln(fp, &buflen)) == NULL)
-		goto end;
-
-	if (buf[buflen-1] == '\n')
-		buf[buflen - 1] = '\0';
-	else {
-		if ((lbuf = calloc(buflen + 1, 1)) == NULL)
-			err(1, "calloc");
-		memcpy(lbuf, buf, buflen);
-	}
-
-	if (strlcpy(hostname, buf, len) >= len)
-		fprintf(stderr, SMTPD_CONFDIR "/mailname entry too long");
-	else {
-		ret = 1;
-		goto end;
-	}
-	
-
-nomailname:
-	if (gethostname(hostname, len) == -1) {
-		fprintf(stderr, "invalid hostname: gethostname() failed\n");
-		goto end;
-	}
-
-	if (strchr(hostname, '.') == NULL) {
-		memset(&hints, 0, sizeof hints);
-		hints.ai_family = PF_UNSPEC;
-		hints.ai_socktype = SOCK_STREAM;
-		hints.ai_protocol = IPPROTO_TCP;
-		hints.ai_flags = AI_CANONNAME;
-		error = getaddrinfo(hostname, NULL, &hints, &res);
-		if (error) {
-			fprintf(stderr, "invalid hostname: getaddrinfo() failed: %s\n",
-			    gai_strerror(error));
-			goto end;
-		}
-		
-		if (strlcpy(hostname, res->ai_canonname, len) >= len) {
-			fprintf(stderr, "hostname too long");
-			goto end;
-		}
-	}
-
-	ret = 1;
-
-end:
-	free(lbuf);
-	if (res)
-		freeaddrinfo(res);
-	if (fp)
-		fclose(fp);
-	return ret;
 }

--- a/smtpd/smtpd.h
+++ b/smtpd/smtpd.h
@@ -1389,6 +1389,7 @@ void log_envelope(const struct envelope *, const char *, const char *,
 void session_socket_blockmode(int, enum blockmodes);
 void session_socket_no_linger(int);
 int session_socket_error(int);
+int getmailname(char *, size_t);
 
 
 /* waitq.c */

--- a/smtpd/util.c
+++ b/smtpd/util.c
@@ -726,3 +726,72 @@ parse_smtp_response(char *line, size_t len, char **msg, int *cont)
 
 	return NULL;
 }
+
+int
+getmailname(char *hostname, size_t len)
+{
+        struct addrinfo hints, *res = NULL;
+        FILE   *fp;
+        char   *buf, *lbuf = NULL;
+        size_t  buflen;
+        int     error;
+        int     ret = 0;
+
+        /* First, check if we have "/etc/mail/mailname" */
+        if ((fp = fopen(SMTPD_CONFDIR "/mailname", "r")) == NULL)
+                goto nomailname;
+
+        if ((buf = fgetln(fp, &buflen)) == NULL)
+                goto end;
+
+        if (buf[buflen-1] == '\n')
+                buf[buflen - 1] = '\0';
+        else {
+                if ((lbuf = calloc(buflen + 1, 1)) == NULL)
+                        err(1, "calloc");
+                memcpy(lbuf, buf, buflen);
+        }
+
+        if (strlcpy(hostname, buf, len) >= len)
+                fprintf(stderr, SMTPD_CONFDIR "/mailname entry too long");
+        else {
+                ret = 1;
+                goto end;
+        }
+
+
+nomailname:
+        if (gethostname(hostname, len) == -1) {
+                fprintf(stderr, "invalid hostname: gethostname() failed\n");
+                goto end;
+        }
+
+        if (strchr(hostname, '.') == NULL) {
+                memset(&hints, 0, sizeof hints);
+                hints.ai_family = PF_UNSPEC;
+                hints.ai_socktype = SOCK_STREAM;
+                hints.ai_protocol = IPPROTO_TCP;
+                hints.ai_flags = AI_CANONNAME;
+                error = getaddrinfo(hostname, NULL, &hints, &res);
+                if (error) {
+                        fprintf(stderr, "invalid hostname: getaddrinfo() failed: %s\n",
+                            gai_strerror(error));
+                        goto end;
+                }
+
+                if (strlcpy(hostname, res->ai_canonname, len) >= len) {
+                        fprintf(stderr, "hostname too long");
+                        goto end;
+                }
+        }
+
+        ret = 1;
+
+end:
+        free(lbuf);
+        if (res)
+                freeaddrinfo(res);
+        if (fp)
+                fclose(fp);
+        return ret;
+}


### PR DESCRIPTION
Use the value of /etc/mail/mailname, where it exists, to complete the address of
local mail in the enqueuer. This is instead of the current approach of using the
local machine's hostname, which results in local mail not being treated as local
by smtpd if the machine's hostname differs from the value of /etc/mail/mailname.
