### PR TITLE
Don't abort on an empty static aliases file

### DIFF
--- a/smtpd/table_static.c
+++ b/smtpd/table_static.c
@@ -135,6 +135,10 @@ table_static_parse(struct table *t, const char *config, enum table_type type)
 		else
 			goto end;
 	}
+	/* Accept empty alias files; treat them as hashes */
+	if (t->t_type == T_NONE && t->t_backend->services & K_ALIAS)
+	    t->t_type = T_HASH;
+
 	ret = 1;
 end:
 	free(lbuf);


### PR DESCRIPTION
An empty static alias file specified via, e.g.,

```
table aliases file:/etc/aliases
```

will cause smtpd to abort with

```
invalid use of table "aliases" as ALIAS parameter.
```

This is because it doesn't get assigned the T_DYNAMIC flag by virtue of using
the static backend. Moreover, since it contains no lines, the backend is unable
to divine whether the file should be treated as a T_HASH or a T_LIST, and so
neither of these flags. Thus, when smtpd checks to see that the « aliases »
table satisfies T_DYNAMIC|T_HASH (neither of which are satisfied by the empty
aliases file) at startup, the check fails and smtpd aborts.
