### PR TITLE
Fix FTBFS on GNU/Hurd due to missing sys/mount.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -263,6 +263,7 @@ AC_CHECK_HEADERS([ \
 	sys/ndir.h \
 	sys/pstat.h \
 	sys/statfs.h \
+	sys/mount.h \
 	sys/un.h \
 	ucred.h \
 	util.h \

--- a/smtpd/queue_fs.c
+++ b/smtpd/queue_fs.c
@@ -27,7 +27,9 @@
 #include <sys/statfs.h>
 #endif
 #include <sys/param.h>
+#if HAVE_SYS_MOUNT_H
 #include <sys/mount.h>
+#endif
 
 #include <ctype.h>
 #include <err.h>


### PR DESCRIPTION
sys/mount.h does not exist on GNU/Hurd, they use sys/statfs.h instead. Only
include sys/mount.h if we aren't on GNU/Hurd.
