### PR TITLE
Check if -lcrypt is needed on GNU/kFreeBSD and GNU/Hurd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -345,7 +345,7 @@ main() { if (NSVersionOfRunTimeLibrary("System") >= (60 << 16))
 		;;
 	esac
 	;;
-*-*-linux*)
+*-*-linux* | *-gnu* | *-k*bsd*-gnu* )
 	check_for_libcrypt_later=1
 	AC_DEFINE([SPT_TYPE], [SPT_REUSEARGV])
 	case `uname -r` in


### PR DESCRIPTION
We do this by giving them the same checks as for GNU/Linux, seeing that they use
a nearly identical toolchain. See the GNU/Hurd porting guidelines[0] for
details.

opensmtpd FTBFS on GNU/kFreeBSD and GNU/Hurd without -lcrypt.

[0] http://www.gnu.org/software/hurd/hurd/porting/guidelines.html
