### PR TITLE
Honor NOTIFY=NEVER.

### DIFF
--- a/smtpd/queue.c
+++ b/smtpd/queue.c
@@ -486,6 +486,9 @@ queue_bounce(struct envelope *e, struct delivery_bounce *d)
 	b.creation = time(NULL);
 	b.expire = 3600 * 24 * 7;
 
+	if (e->dsn_notify & DSN_NEVER)
+		return;
+
 	if (b.id == 0)
 		log_warnx("warn: queue_bounce: evpid=0");
 	if (evpid_to_msgid(b.id) == 0)


### PR DESCRIPTION
When requested to never send a DSN (bounce) this diff works for the simple case like wrong username. I haven't tested it for all the failures types where a bounce could be generated but from my understanding every bounce is generated through queue_bounce function so it should work for remaining cases too. mail -s foo nonexistent@bar.org -NNEVER wouldn't generate a bounce now. Please review.
