### PR TITLE
Rename the variable for clarity.

### DIFF
--- a/smtpd/bounce.c
+++ b/smtpd/bounce.c
@@ -444,7 +444,7 @@ bounce_next(struct bounce_session *s)
 			break;
 		case B_DSN:
 			iobuf_xfqueue(&s->iobuf, "bounce_next: BODY",
-			    s->msg->bounce.mta_nodsn ?
+			    s->msg->bounce.mta_with_dsn ?
 			    notice_relay : notice_success);
 			break;
 		default:

--- a/smtpd/queue.c
+++ b/smtpd/queue.c
@@ -346,14 +346,14 @@ queue_imsg(struct mproc *p, struct imsg *imsg)
 				bounce.type = B_DSN;
 				bounce.delay = 0;
 				bounce.expire = 0;
-				bounce.mta_nodsn = 0;
+				bounce.mta_with_dsn = 0;
 				bounce.dsn_ret = evp.dsn_ret;
 
 				if (p->proc == PROC_MDA)
 					queue_bounce(&evp, &bounce);
 				else if (p->proc == PROC_MTA &&
 				    (mta_ext & MTA_EXT_DSN) == 0) {
-					bounce.mta_nodsn = 1;
+					bounce.mta_with_dsn = 1;
 					queue_bounce(&evp, &bounce);
 
 				}

--- a/smtpd/smtpd.h
+++ b/smtpd/smtpd.h
@@ -389,7 +389,7 @@ struct delivery_bounce {
 	time_t			delay;
 	time_t			expire;
 	enum dsn_ret		dsn_ret;
-        int			mta_nodsn;
+        int			mta_with_dsn;
 };
 
 enum expand_type {


### PR DESCRIPTION
This variable name caused some confusion during the code review. Renaming it for better clarity.
