### PR TITLE
Add Makefiles for OpenBSD version of table-redis

### DIFF
--- a/smtpd/Makefile
+++ b/smtpd/Makefile
@@ -11,5 +11,6 @@ SUBDIR+=	table-passwd
 #SUBDIR+=	table-postgres
 SUBDIR+=	table-sqlite
 SUBDIR+=	table-stub
+#SUBDIR+=	table-redis
 
 .include <bsd.subdir.mk>

--- a/smtpd/table-redis/Makefile
+++ b/smtpd/table-redis/Makefile
@@ -1,0 +1,28 @@
+#	$OpenBSD$
+
+.PATH: ${.CURDIR}/..
+
+PROG=	table-redis
+
+SRCS=	table_redis.c
+SRCS+=	table_api.c
+SRCS+=	dict.c
+SRCS+=	log.c
+
+NOMAN=	noman
+
+BINDIR=	/usr/libexec/smtpd
+
+DPADD=	${LIBUTIL}
+LDADD=	-lutil -L/usr/local/lib -lhiredis
+
+CFLAGS+=	-I/usr/local/include/hiredis
+CFLAGS+=	-g3 -ggdb -I${.CURDIR}/..
+CFLAGS+=	-Wall -Wstrict-prototypes -Wmissing-prototypes
+CFLAGS+=	-Wmissing-declarations
+CFLAGS+=	-Wshadow -Wpointer-arith -Wcast-qual
+CFLAGS+=	-Wsign-compare -Wbounded
+CFLAGS+=	-DNO_IO
+#CFLAGS+=	-Werror # during development phase (breaks some archs) 
+
+.include <bsd.prog.mk>


### PR DESCRIPTION
I think this is what is missing to be able to merge with master branch. Note that it needs hiredis to be installed (http://openbsd.7691.n7.nabble.com/NEW-databases-hiredis-td142092.html).
