### PR TITLE
Unbreak portable and lua Makefile

### DIFF
--- a/mk/filters/lua/Makefile.am
+++ b/mk/filters/lua/Makefile.am
@@ -1,0 +1,9 @@
+include $(top_srcdir)/mk/pathnames
+include $(top_srcdir)/mk/filter.mk
+
+pkglibexec_PROGRAMS	 = filter-lua
+
+filter_lua_SOURCES	 = $(SRCS)
+filter_lua_SOURCES	 += $(filters_srcdir)/filter_lua.c
+filter_lua_CFLAGS	 = `pkg-config --cflags lua-5.2`
+filter_lua_LDFLAGS	 = `pkg-config --libs lua-5.2`


### PR DESCRIPTION
- Add initial mk for lua filter
  - Remove lua filter from configure.ac for now

If you want to test the lua filters : 
add mk/filters/lua/Makefile just after mk/filters/dnsbl/Makefile in configure.ac
add lua mk/filters/Makefile.am
