### PR TITLE
Zero initialize static buffer before use.

### DIFF
--- a/smtpd/mta_session.c
+++ b/smtpd/mta_session.c
@@ -1599,6 +1599,7 @@ dsn_strnotify(uint8_t arg)
 	static char	buf[32];
 	size_t		sz;
 
+	buf[0] = '\0';
 	if (arg & DSN_SUCCESS)
 		strlcat(buf, "SUCCESS,", sizeof(buf));
 


### PR DESCRIPTION
ElBarto on IRC reported an issue with DSN that a second and subsequent mails to a reciepient with same DSN parameters gets rejected with "Bad NOTIFY parameter" error. This diff fixes the problem by properly zero initializing the static buffer thereby removing any stale content in it. 
