### PR TITLE
Avoid excessive warnings about redefined macros

### DIFF
--- a/openbsd-compat/defines.h
+++ b/openbsd-compat/defines.h
@@ -373,13 +373,13 @@ struct winsize {
 #endif
 
 /* user may have set a different path */
-#if defined(_PATH_MAILDIR) && defined(MAIL_DIRECTORY)
-# undef _PATH_MAILDIR MAILDIR
-#endif /* defined(_PATH_MAILDIR) && defined(MAIL_DIRECTORY) */
+#if !defined(_PATH_MAILDIR) && defined(MAILDIR)
+# define _PATH_MAILDIR MAILDIR
+#endif /* !defined(_PATH_MAILDIR) && defined(MAIL_DIRECTORY) */
 
-#ifdef MAIL_DIRECTORY
+#if !defined(_PATH_MAILDIR) && defined(MAIL_DIRECTORY)
 # define _PATH_MAILDIR MAIL_DIRECTORY
-#endif
+#endif /* !defined(_PATH_MAILDIR) && defined(MAIL_DIRECTORY) */
 
 #ifdef MAILDIR
 # undef MAILDIR


### PR DESCRIPTION
Avoid excessive warnings about redefined macros

I can't vouch for the correctness of the patch. However, it does succeed in eliminating the endless stream of warnings of the form:

```
gcc -DHAVE_CONFIG_H -I. -I../../..  -I../../../smtpd -I../../../openbsd-compat -I../../../contrib/lib/libc/asr -D_FORTIFY_SOURCE=2 -DASR_OPT_THREADSAFE=0 -DNO_IO -DBUILD_FILTER -c -o ../../../smtpd/filter_dnsbl-util.o `test -f '../../../smtpd/util.c' || echo './'`../../../smtpd/util.c
In file included from ../../../openbsd-compat/includes.h:75:0,
                 from ../../../smtpd/util.c:22:
../../../openbsd-compat/defines.h:377:23: warning: extra tokens at end of #undef directive [enabled by default]
 # undef _PATH_MAILDIR MAILDIR
                       ^
```

Please consider applying it or a variant thereof.

Patch by Benny Baumann BenBE@geshi.org. Originally submitted as Debian Bug 747666: https://bugs.debian.org/747666
