### PR TITLE
Adding some OpenBSD into to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Dependencies
 Portable OpenSMTPD relies on:
 * [autoconf](http://www.gnu.org/software/autoconf/)
 * [automake](http://www.gnu.org/software/automake/)
-* [Berkeley DB](http://www.oracle.com/technetwork/products/berkeleydb/overview/index.html) to be built with --enable-compat185 configure flag
+* [Berkeley DB](http://www.oracle.com/technetwork/products/berkeleydb/overview/index.html)
 * [bison](http://www.gnu.org/software/bison/) (or [byacc](http://invisible-island.net/byacc/byacc.html))
 * [libevent](http://libevent.org/)
 * [libtool](http://www.gnu.org/software/libtool/)
@@ -49,18 +49,36 @@ Get the source
 
 or
 
-    wget http://www.opensmtpd.org/archives/opensmtpd-portable-latest.tar.gz
+    wget https://www.opensmtpd.org/archives/opensmtpd-portable-latest.tar.gz
     tar xzvf opensmtpd-portable-latest.tar.gz
 
+If you happen to be running OpenBSD you can do the same with
+
+    git clone -b master git://github.com/OpenSMTPD/OpenSMTPD.git opensmtpd
+or
+
+    wget https://www.opensmtpd.org/archives/opensmtpd-latest.tar.gz
+    tar xzvf opensmtpd-latest.tar.gz	
 
 Build
 -----
 
+Portable
+---
+
     cd opensmtpd*
-    ./bootstrap  # Only if you build from git sources
+    ./bootstrap  
     ./configure  
     make  
-    sudo make install  
+    sudo make install
+
+OpenBSD
+---
+
+    cd opensmtpd*
+    if you are using the git branch cd smtpd
+    make
+    sudo make install
 
 ### Special notes for FreeBSD/DragonFlyBSD/Mac OS X:
 
@@ -96,15 +114,11 @@ Add OpenSMTPD users
 -------------------
 
 To operate, OpenSMTPD requires at least one user, by default _smtpd; and
-preferably two users, by default _smtpd and _smtpq.
-
-Using two users instead of one will increase security by a large factor so...
-unless you want to voluntarily reduce security or you have absolute more faith in our code than we do, by all means use two.
-
+preferably three users, by default _smtpd, _smtpq and _smtpf.
 
 The instructions below assume the default users however, the configure
 script allows overriding these using the options:
---with-privsep-user, --with-queue-user.
+--with-privsep-user, --with-queue-user and --with-filter-user.
 
 
 ### NetBSD, Linux (Debian, ArchLinux, ...)
@@ -112,11 +126,13 @@ script allows overriding these using the options:
     mkdir /var/empty  
     useradd -c "SMTP Daemon" -d /var/empty -s /sbin/nologin _smtpd
     useradd -c "SMTP queue user" -d /var/empty -s /sbin/nologin _smtpq
+    useradd -c "SMTP filter user" -d /var/empty -s /sbin/nologin _smtpf
 
 ### DragonFlyBSD, FreeBSD
 
     pw useradd _smtpd -c "SMTP Daemon" -d /var/empty -s /sbin/nologin
     pw useradd _smtpq -c "SMTP queue user" -d /var/empty -s /sbin/nologin
+    pw useradd _smtpf -c "SMTP filter user" -d /var/empty -s /sbin/nologin
 
 ### Mac OS X
 
@@ -145,7 +161,7 @@ Add a user - here we have picked 444:
 	/usr/bin/sudo /usr/bin/dscl . -create /Users/_smtpd NFSHomeDirectory /var/empty
 	/usr/bin/sudo /usr/bin/dscl . -create /Users/_smtpd UserShell /usr/bin/false
 
-repeat for the _smtpq user.
+repeat for the _smtpq and _smtpf users.
 
 
 Launch smtpd


### PR DESCRIPTION
Even though it should be familiar and obvious to OpenBSD users, I added source instructions for them since they do differ from the portable build.
