### PR TITLE
fix socketpair leak in 'pony'

### DIFF
--- a/smtpd/smtp_session.c
+++ b/smtpd/smtp_session.c
@@ -278,6 +278,7 @@ smtp_session(struct listener *listener, int sock,
 	io_init(&s->io, sock, s, smtp_io, &s->iobuf);
 	io_set_timeout(&s->io, SMTPD_SESSION_TIMEOUT * 1000);
 	io_set_write(&s->io);
+	io_init(&s->oev, -1, s, NULL, NULL); /* initialise 'sock', but not to 0 */
 
 	s->state = STATE_NEW;
 	s->phase = PHASE_INIT;


### PR DESCRIPTION
On smtp connection exception the socketpair used to i/o the data phase
is not freed. Whenever IMSG_SMTP_MESSAGE_ROLLBACK is signalled to
'queue', 'pony' should release the io resources related to the
socketpair. There are four such exceptions in smtp_io():
IO_{TIMEOUT,DISCONNECTED,ERROR} and SF_BADINPUT.

The fix was tested on a live server, previously affected by this leak.
