### PR TITLE
Introduces "limit session" keywords to replace fixed values

### DIFF
--- a/smtpd/smtp_session.c
+++ b/smtpd/smtp_session.c
@@ -44,9 +44,6 @@
 #include "log.h"
 #include "ssl.h"
 
-#define SMTP_LIMIT_MAIL		100
-#define SMTP_LIMIT_RCPT		1000
-
 #define SMTP_KICK_CMD		5
 #define SMTP_KICK_RCPTFAIL	50
 
@@ -1250,7 +1247,7 @@ smtp_command(struct smtp_session *s, char *line)
 			break;
 		}
 
-		if (s->mailcount >= SMTP_LIMIT_MAIL) {
+		if (s->mailcount >= env->sc_session_max_mails) {
 			/* we can pretend we had too many recipients */
 			smtp_reply(s, "452 %s %s: Too many messages sent",
 			    esc_code(ESC_STATUS_TEMPFAIL, ESC_TOO_MANY_RECIPIENTS),
@@ -1282,7 +1279,7 @@ smtp_command(struct smtp_session *s, char *line)
 			break;
 		}
 
-		if (s->rcptcount >= SMTP_LIMIT_RCPT) {
+		if (s->rcptcount >= env->sc_session_max_rcpt) {
 			smtp_reply(s, "451 %s %s: Too many recipients",
 			    esc_code(ESC_STATUS_TEMPFAIL, ESC_TOO_MANY_RECIPIENTS),
 			    esc_description(ESC_TOO_MANY_RECIPIENTS));

--- a/smtpd/smtpd.conf.5
+++ b/smtpd/smtpd.conf.5
@@ -562,6 +562,17 @@ expire 4d	# expire after 4 days
 expire 10h	# expire after 10 hours
 .Ed
 .It Xo
+.Ic limit session
+.Brq Cm max-rcpt | max-mails
+.Ar num
+.Xc
+Instruct   
+.Xr smtpd 8
+to accept a maximum number of recipients or emails at once in the receiving queue. Defaults are 100 for 
+.Ic max-mails 
+and 1000 for 
+.Ic max-rcpt .
+.It Xo
 .Ic limit mta
 .Op Ic for Ic domain Ar domain
 .Ar family

--- a/smtpd/smtpd.h
+++ b/smtpd/smtpd.h
@@ -556,6 +556,9 @@ struct smtpd {
 	char			       *sc_queue_key;
 	size_t				sc_queue_evpcache_size;
 
+	size_t				sc_session_max_rcpt;
+	size_t				sc_session_max_mails;
+
 	size_t				sc_mda_max_session;
 	size_t				sc_mda_max_user_session;
 	size_t				sc_mda_task_hiwat;


### PR DESCRIPTION
max-rcpt to replace SMTP_LIMIT_RCPT
max-mails to replace SMTP_LIMIT_MAIL

Should solve "issue" 486
https://github.com/OpenSMTPD/OpenSMTPD/issues/486
