### PR TITLE
Remove duplicate definition of imsg_to_str.

### DIFF
--- a/smtpd/filter_api.c
+++ b/smtpd/filter_api.c
@@ -674,17 +674,6 @@ proc_name(enum smtp_proc_type proc)
 	return ("filter");
 }
 
-const char *
-imsg_to_str(int imsg)
-{
-	static char buf[32];
-
-	snprintf(buf, sizeof(buf), "%d", imsg);
-
-	return (buf);
-}
-
-
 /*
  * These functions are callable by filters
  */


### PR DESCRIPTION
smtpd.c imsg_to_str is the correct version. ctags gets confused and takes us to wrong
definition.