### PR TITLE
Fix permissions for directory PATH_PURGE

### DIFF
--- a/smtpd/queue_backend.c
+++ b/smtpd/queue_backend.c
@@ -141,7 +141,7 @@ queue_init(const char *name, int server)
 			errx(1, "error in spool directory setup");
 		if (ckdir(PATH_SPOOL PATH_OFFLINE, 01777, 0, 0, 1) == 0)
 			errx(1, "error in offline directory setup");
-		if (ckdir(PATH_SPOOL PATH_PURGE, 0700, pwq->pw_uid, 0, 1) == 0)
+		if (ckdir(PATH_SPOOL PATH_PURGE, 0750, pwq->pw_uid, 0, 1) == 0)
 			errx(1, "error in purge directory setup");
 
 		mvpurge(PATH_SPOOL PATH_TEMPORARY, PATH_SPOOL PATH_PURGE);


### PR DESCRIPTION
Receiving this error:

    warn: purge_task: opendir: Permission denied

With capability CAP_DAC_OVERRIDE dropped. Root also needs to be able to
access the directory PATH_PURGE.