### PR TITLE
[TLS] Use correct function to determine session protocol version

### DIFF
--- a/smtpd/smtp_session.c
+++ b/smtpd/smtp_session.c
@@ -1272,7 +1272,7 @@ smtp_filter_fd(uint64_t id, int fd)
 		x = SSL_get_peer_certificate(s->io.ssl);
 		iobuf_fqueue(&s->obuf,
 		    "\n\tTLS version=%s cipher=%s bits=%d verify=%s",
-		    SSL_get_cipher_version(s->io.ssl),
+		    SSL_get_version(s->io.ssl),
 		    SSL_get_cipher_name(s->io.ssl),
 		    SSL_get_cipher_bits(s->io.ssl, NULL),
 		    (s->flags & SF_VERIFIED) ? "YES" : (x ? "FAIL" : "NO"));

--- a/smtpd/ssl.c
+++ b/smtpd/ssl.c
@@ -363,19 +363,9 @@ const char *
 ssl_to_text(const SSL *ssl)
 {
 	static char	buf[256];
-	static char	description[128];
-	char	       *tls_version = NULL;
 
-	/*
-	 * SSL_get_cipher_version() does not know about the exact TLS version...
-	 * you have to pick it up from second field of the SSL cipher description !
-	 */
-	SSL_CIPHER_description(SSL_get_current_cipher(ssl), description, sizeof description);
-	tls_version = strchr(description, ' ') + 1;
-	tls_version[strcspn(tls_version, " ")] = '\0';
-	(void)snprintf(buf, sizeof buf, "version=%s (%s), cipher=%s, bits=%d",
-	    SSL_get_cipher_version(ssl),
-	    tls_version,
+	(void) snprintf(buf, sizeof buf, "version=%s, cipher=%s, bits=%d",
+	    SSL_get_version(ssl),
 	    SSL_get_cipher_name(ssl),
 	    SSL_get_cipher_bits(ssl, NULL));
 


### PR DESCRIPTION
SSL_get_cipher_version() returns the version of SSL/TLS that the
ciphersuite was introduced/defined in, not the version in use for
the connection.

Use SSL_get_version() instead.