### PR TITLE
Don't remove the BCC-field

### DIFF
--- a/smtpd/smtp_session.c
+++ b/smtpd/smtp_session.c
@@ -152,7 +152,6 @@ struct smtp_session {
 	int			 rcvcount;
 	int			 dataeom;
 
-	int			 skiphdr;
 	struct event		 pause;
 
 	struct rfc2822_parser	 rfc2822_parser;
@@ -1412,18 +1411,6 @@ smtp_io(struct io *io, int evt)
 				line += 1;
 				len -= 1;
 			}
-
-			if (isspace((unsigned char)line[0]) && s->skiphdr)
-                                goto nextline;
-                        s->skiphdr = 0;
-
-                        /* BCC should be stripped from headers */
-                        if (! s->hdrdone) {
-                                if (strncasecmp("bcc:", line, 4) == 0) {
-                                        s->skiphdr = 1;
-                                        goto nextline;
-                                }
-                        }
 
 			log_trace(TRACE_SMTP, "<<< [MSG] %s", line);
 			smtp_filter_dataline(s, line);


### PR DESCRIPTION
According to the RCF 5322 there are some reasons a message
contains a Bcc-field.

This reverts commit 40aaa643bd035f132214e0e8a2d37f77a83a5af2.

According to the RFC 2 of 3 ways to implement Bcc will result in messages
with a Bcc-field.
see: https://tools.ietf.org/html/rfc5322#section-3.6.3