### PR TITLE
check for AF_LOCAL and define to AF_UNIX if not

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -662,6 +662,10 @@ AC_CHECK_DECLS([howmany, NFDBITS], [], [], [[
 #include <unistd.h>
 #endif
 	]])
+
+AC_CHECK_DECLS([AF_LOCAL], , , [
+#include <sys/socket.h>
+	])
 AC_CHECK_TYPES([fd_mask], [], [], [[
 #include <sys/param.h>
 #include <sys/types.h>

--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -218,4 +218,8 @@ void errc(int, int, const char *, ...);
 #define pledge(promises, paths) 0
 #endif
 
+#if !HAVE_DECL_AF_LOCAL
+#define AF_LOCAL AF_UNIX
+#endif
+
 #endif /* _OPENBSD_COMPAT_H */


### PR DESCRIPTION
Because Solaris don't have AF_LOCAL