### PR TITLE
use ss_len only if exists

### DIFF
--- a/smtpd/parse.y
+++ b/smtpd/parse.y
@@ -2081,7 +2081,9 @@ create_sock_listener(struct listen_opts *lo)
 	lo->tag = "local";
 	lo->hostname = conf->sc_hostname;
 	l->ss.ss_family = AF_LOCAL;
+#ifdef HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN
 	l->ss.ss_len = sizeof(struct sockaddr *);
+#endif
 	config_listener(l, lo);
 
 	return (l);


### PR DESCRIPTION
each lines of code using ss_len are surrounded by #if have_struct_sockaddr_storage_ss_len