### PR TITLE
set IPV6_V6ONLY if available

### DIFF
--- a/smtpd/smtp.c
+++ b/smtpd/smtp.c
@@ -160,6 +160,15 @@ smtp_setup_listeners(void)
 			sizeof(opt)) < 0)
 			fatal("smtpd: setsockopt");
 #endif
+#ifdef IPV6_V6ONLY
+		/* If using IPv6, bind only to IPv6 if possible. This avoids
+		   ambiguities with IPv4-mapped IPv6 addresses. */
+		if (l->ss.ss_family == AF_INET6) {
+				if (setsockopt(l->fd, IPPROTO_IPV6, IPV6_V6ONLY, &opt,
+						sizeof(opt)) < 0)
+						fatal("smtpd: setsockopt");
+		}
+#endif
 		if (bind(l->fd, (struct sockaddr *)&l->ss, SS_LEN(&l->ss)) == -1)
 			fatal("smtpd: bind");
 	}


### PR DESCRIPTION
When trying to listen for exanple on both `0.0.0.0` and `::`, the IPv6 listen would fail with "Address already in use" because it's also trying to bind on IPv4 for mapping IPv4 to IPv6.

I'm really not sure how to handle this, but it seems like the other softwares I'm running (Dovecot, NGINX) all explicitly set `IPV6_V6ONLY` to `1` (see for [Dovecot](https://github.com/dovecot/core/blob/7c925149e49f7cce41c90d562ff3835b66ddca29/src/lib/net.c#L445) and [NGINX](https://github.com/nginx/nginx/blob/2ce791f2cddff967fd3bcbbedcd4ea283a9c77e1/src/core/ngx_connection.c#L490)).

This PR adds this option for IPv6 sockets if supported.