### PR TITLE
Add ability to set PATH_LIBEXEC at runtime via env var

### DIFF
--- a/smtpd/parse.y
+++ b/smtpd/parse.y
@@ -2534,13 +2534,19 @@ create_filter_proc(char *name, char *prog)
 {
 	struct filter_conf	*f;
 	char			*path;
+	const char		*proc_path;
 
 	if (dict_get(&conf->sc_filters, name)) {
 		yyerror("filter \"%s\" already defined", name);
 		return (NULL);
 	}
 
-	if (asprintf(&path, "%s/filter-%s", PATH_LIBEXEC, prog) == -1) {
+	proc_path = getenv("OPENSMTPD_PROC_PATH");
+	if (proc_path == NULL) {
+		proc_path = PATH_LIBEXEC;
+	}
+
+	if (asprintf(&path, "%s/filter-%s", proc_path, prog) == -1) {
 		yyerror("filter \"%s\" asprintf failed", name);
 		return (0);
 	}

--- a/smtpd/smtpd.c
+++ b/smtpd/smtpd.c
@@ -795,6 +795,7 @@ fork_proc_backend(const char *key, const char *conf, const char *procname)
 	char		path[PATH_MAX];
 	char		name[PATH_MAX];
 	char		*arg;
+	char		*proc_path;
 
 	if (strlcpy(name, conf, sizeof(name)) >= sizeof(name)) {
 		log_warnx("warn: %s-proc: conf too long", key);
@@ -805,7 +806,12 @@ fork_proc_backend(const char *key, const char *conf, const char *procname)
 	if (arg)
 		*arg++ = '\0';
 
-	if (snprintf(path, sizeof(path), PATH_LIBEXEC "/%s-%s", key, name) >=
+	proc_path = getenv("OPENSMTPD_PROC_PATH");
+	if (proc_path == NULL) {
+		proc_path = PATH_LIBEXEC;
+	}
+
+	if (snprintf(path, sizeof(path), "%s/%s-%s", proc_path, key, name) >=
 	    (ssize_t)sizeof(path)) {
 		log_warn("warn: %s-proc: exec path too long", key);
 		return (-1);

--- a/smtpd/table.c
+++ b/smtpd/table.c
@@ -193,6 +193,7 @@ table_create(const char *backend, const char *name, const char *tag,
 	struct table_backend	*tb;
 	char			 buf[LINE_MAX];
 	char			 path[LINE_MAX];
+	const char		*proc_path;
 	size_t			 n;
 	struct stat		 sb;
 
@@ -207,11 +208,16 @@ table_create(const char *backend, const char *name, const char *tag,
 	if (name && table_find(name, NULL))
 		fatalx("table_create: table \"%s\" already defined", name);
 
+	proc_path = getenv("OPENSMTPD_PROC_PATH");
+	if (proc_path == NULL) {
+		proc_path = PATH_LIBEXEC;
+	}
+
 	if ((tb = table_backend_lookup(backend)) == NULL) {
-		if ((size_t)snprintf(path, sizeof(path), PATH_LIBEXEC"/table-%s",
-			backend) >= sizeof(path)) {
-			fatalx("table_create: path too long \""
-			    PATH_LIBEXEC"/table-%s\"", backend);
+		if ((size_t)snprintf(path, sizeof(path), "%s/table-%s",
+			proc_path, backend) >= sizeof(path)) {
+			fatalx("table_create: path too long \"%s/table-%s\"",
+				proc_path, backend);
 		}
 		if (stat(path, &sb) == 0) {
 			tb = table_backend_lookup("proc");


### PR DESCRIPTION
Originally written by @gebner for NixOS

The location where filters & co are going to be can't always be known at compile time. This patch adds the ability to override `PATH_LIBEXEC` at runtime using the `OPENSMTPD_PROC_PATH` environment variable.