### PR TITLE
Support multiline responses from lmtp servers.

### DIFF
--- a/smtpd/delivery_lmtp.c
+++ b/smtpd/delivery_lmtp.c
@@ -187,10 +187,10 @@ lmtp_cmd(char **buf, size_t *sz, int code, FILE *fp, const char *fmt, ...)
 	if (fflush(fp) != 0)
 		err(1, "fflush");
 
-    do {
-	if ((len = getline(buf, sz, fp)) == -1)
-		err(1, "getline");
-    } while((*buf)[3] != ' ');
+	do {
+		if ((len = getline(buf, sz, fp)) == -1)
+			err(1, "getline");
+	} while((*buf)[3] != ' ');
 
 	bufp = *buf;
 	if (len >= 2 && bufp[len - 2] == '\r')

--- a/smtpd/delivery_lmtp.c
+++ b/smtpd/delivery_lmtp.c
@@ -36,6 +36,8 @@
 
 #include "smtpd.h"
 
+#define MAX_CONTINUATIONS 20
+
 static int	inet_socket(char *);
 static int	lmtp_cmd(char **buf, size_t *, int, FILE *, const char *, ...)
 		    __attribute__((__format__ (printf, 5, 6)))
@@ -175,6 +177,7 @@ lmtp_cmd(char **buf, size_t *sz, int code, FILE *fp, const char *fmt, ...)
 	va_list	 ap;
 	char	*bufp;
 	ssize_t	 len;
+	unsigned int continuations = 0;
 
 	va_start(ap, fmt);
 	if (vfprintf(fp, fmt, ap) < 0)
@@ -192,6 +195,8 @@ lmtp_cmd(char **buf, size_t *sz, int code, FILE *fp, const char *fmt, ...)
 			err(1, "getline");
 		if (len < 4)
 			errx(1, "Server response line too short");
+		if (continuations++ >= MAX_CONTINUATIONS)
+			errx(1, "Too many continuations in response");
 	} while((*buf)[3] != ' ');
 
 	bufp = *buf;

--- a/smtpd/delivery_lmtp.c
+++ b/smtpd/delivery_lmtp.c
@@ -197,7 +197,7 @@ lmtp_cmd(char **buf, size_t *sz, int code, FILE *fp, const char *fmt, ...)
 			errx(1, "Server response line too short");
 		if (continuations++ >= MAX_CONTINUATIONS)
 			errx(1, "Too many continuations in response");
-	} while((*buf)[3] != ' ');
+	} while((*buf)[3] == '-');
 
 	bufp = *buf;
 	if (len >= 2 && bufp[len - 2] == '\r')

--- a/smtpd/delivery_lmtp.c
+++ b/smtpd/delivery_lmtp.c
@@ -187,8 +187,10 @@ lmtp_cmd(char **buf, size_t *sz, int code, FILE *fp, const char *fmt, ...)
 	if (fflush(fp) != 0)
 		err(1, "fflush");
 
+    do {
 	if ((len = getline(buf, sz, fp)) == -1)
 		err(1, "getline");
+    } while((*buf)[3] != ' ');
 
 	bufp = *buf;
 	if (len >= 2 && bufp[len - 2] == '\r')

--- a/smtpd/delivery_lmtp.c
+++ b/smtpd/delivery_lmtp.c
@@ -190,6 +190,8 @@ lmtp_cmd(char **buf, size_t *sz, int code, FILE *fp, const char *fmt, ...)
 	do {
 		if ((len = getline(buf, sz, fp)) == -1)
 			err(1, "getline");
+		if (len < 4)
+			errx(1, "Server response line too short");
 	} while((*buf)[3] != ' ');
 
 	bufp = *buf;


### PR DESCRIPTION
Fixes #694 in which multiline responses from dovecot (and probably other LMTP servers) were not being anticipated by OpenSMTPD.

With this little change, OpenSMTPD will continue to read lines until the 4th character (i.e. character after the status code) is a space, indicating no more lines will be added to the response.

(first github pull request, hopefully I've done this right!)