### PR TITLE
Fix expression

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -346,7 +346,7 @@ AC_CHECK_DECLS([O_NONBLOCK], [], [], [
 #endif
 ])
 
-AC_CHECK_DECLS([AF_LOCAL], [], [], [
+AC_CHECK_DECLS([AF_LOCAL, PF_LOCAL], [], [], [
 #include <sys/socket.h>
 ])
 

--- a/openbsd-compat/defines.h
+++ b/openbsd-compat/defines.h
@@ -85,7 +85,7 @@
 # define STDERR_FILENO   2
 #endif
 
-#if defined(HAVE_DECL_O_NONBLOCK) && HAVE_DECL_O_NONBLOCK == 0
+#if !HAVE_DECL_O_NONBLOCK
 # define O_NONBLOCK      00004	/* Non Blocking Open */
 #endif
 

--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -212,11 +212,11 @@ void errc(int, int, const char *, ...);
 #define pledge(promises, paths) 0
 #endif
 
-#ifndef HAVE_DECL_AF_LOCAL
+#if !HAVE_DECL_AF_LOCAL
 #define AF_LOCAL AF_UNIX
 #endif
 
-#ifndef HAVE_DECL_WAIT_MYPGRP
+#if !HAVE_DECL_WAIT_MYPGRP
 #define WAIT_MYPGRP 0
 #endif
 

--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -216,6 +216,10 @@ void errc(int, int, const char *, ...);
 #define AF_LOCAL AF_UNIX
 #endif
 
+#if !HAVE_DECL_PF_LOCAL
+#define PF_LOCAL PF_UNIX
+#endif
+
 #if !HAVE_DECL_WAIT_MYPGRP
 #define WAIT_MYPGRP 0
 #endif


### PR DESCRIPTION
As explain in
https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Generic-Declarations.html#Generic-Declarations

"Unlike the other `AC_CHECK_*S' macros, when a symbol is not
declared, HAVE_DECL_symbol is defined to `0' instead of
leaving HAVE_DECL_symbol undeclared."