### PR TITLE
move --with-libs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -371,6 +371,14 @@ AC_CHECK_DECLS([writev], [], [], [
 AC_C_INLINE
 
 
+AC_ARG_WITH([libs],
+	[  --with-libs			Specify additional libraries to link with],
+	[
+		if test -n "$withval" -a "$withval" != "no" -a "${withval}" != "yes"; then
+			LIBS="$LIBS $withval"
+		fi
+	]
+)
 #
 # CHECKS FOR LIBRARY FUNCTIONS
 #
@@ -704,14 +712,6 @@ AC_ARG_WITH([ldflags],
 	[
 		if test -n "$withval" -a "$withval" != "xno" -a "${withval}" != "yes"; then
 			LDFLAGS="$LDFLAGS $withval"
-		fi
-	]
-)
-AC_ARG_WITH([libs],
-	[  --with-libs			Specify additional libraries to link with],
-	[
-		if test -n "$withval" -a "$withval" != "no" -a "${withval}" != "yes"; then
-			LIBS="$LIBS $withval"
 		fi
 	]
 )


### PR DESCRIPTION
On Solaris, inet_aton and inet_ntoa require '-lsocket -lnsl'.
configure.ac can't find this functions:

...
checking for inet_ntoa... no
checking for inet_ntop... no
...
Libraries: -lz -lcrypto -lssl -levent -lasr -lsocket -lfts -lrt -lresolv

Add "--with-libs='-lnsl'" don't fix:

...
checking for inet_ntoa... no
checking for inet_ntop... no
...
Libraries: -lz -lcrypto -lssl -levent -lasr -lsocket -lfts -lrt -lresolv  -lnsl

Because --with-libs is check too late. Move it before 'AC_SEARCH_LIBS' fix the problem:

...
checking for inet_ntoa... yes
checking for inet_ntop... yes
...
Libraries: -lz -lcrypto -lssl -levent -lasr -lsocket -lfts -lrt -lresolv  -lnsl