### PR TITLE
Xclosefrom

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -390,6 +390,23 @@ AC_SEARCH_LIBS([basename],
 	])
 AM_CONDITIONAL([SUPPORT_BASENAME], [test $BASENAME_SUPPORT = yes])
 
+
+CLOSEFROM_SUPPORT=no
+AC_SEARCH_LIBS([closefrom],
+	[gen],
+	[
+		AC_DEFINE([HAVE_CLOSEFROM], [1], 
+			[Define if you have the closefrom() function.])
+		CLOSEFROM_SUPPORT=yes
+        AC_COMPILE_IFELSE(
+            [
+                AC_LANG_PROGRAM([AC_INCLUDES_DEFAULT], [[int res = closefrom(0);]])
+            ],
+            AC_DEFINE(HAVE_CLOSEFROM_INT, 1, [closefrom return int])
+        )
+	])
+AM_CONDITIONAL([SUPPORT_CLOSEFROM], [test $CLOSEFROM_SUPPORT = yes])
+
 UTIMES_SUPPORT=no
 AC_SEARCH_LIBS([utimes],
 	[c89],
@@ -516,7 +533,6 @@ AC_CHECK_FUNCS([ \
 	__b64_pton \
 	bcopy \
 	chflags \
-	closefrom \
 	dirfd \
 	endgrent \
 	explicit_bzero \

--- a/openbsd-compat/Makefile.am
+++ b/openbsd-compat/Makefile.am
@@ -1,7 +1,7 @@
 noinst_LIBRARIES = libopenbsd-compat.a
 
 libopenbsd_compat_a_SOURCES =							\
-		arc4random.c base64.c bsd-closefrom.c		\
+		arc4random.c base64.c 		\
 		bsd-getpeereid.c bsd-misc.c bsd-waitpid.c 	\
 		entropy.c errc.c event_asr_run.c explicit_bzero.c	\
 		fgetln.c flock.c getopt.c imsg.c imsg-buffer.c	\
@@ -15,6 +15,10 @@ endif
 
 if !SUPPORT_CLOCK_GETTIME
 libopenbsd_compat_a_SOURCES += clock_gettime.c
+endif
+
+if !SUPPORT_CLOSEFROM
+libopenbsd_compat_a_SOURCES += bsd-closefrom.c
 endif
 
 if !SUPPORT_DAEMON

--- a/smtpd/smtpd.c
+++ b/smtpd/smtpd.c
@@ -867,7 +867,7 @@ start_child(int save_argc, char **save_argv, char *rexec)
 	if (dup2(sp[0], 3) == -1)
 		fatal("%s: dup2", rexec);
 
-	if (closefrom(4) == -1)
+	if (xclosefrom(4) == -1)
 		fatal("%s: closefrom", rexec);
 
 	for (argc = 0; argc < save_argc; argc++)

--- a/smtpd/smtpd.c
+++ b/smtpd/smtpd.c
@@ -867,8 +867,7 @@ start_child(int save_argc, char **save_argv, char *rexec)
 	if (dup2(sp[0], 3) == -1)
 		fatal("%s: dup2", rexec);
 
-	if (xclosefrom(4) == -1)
-		fatal("%s: closefrom", rexec);
+	xclosefrom(4);
 
 	for (argc = 0; argc < save_argc; argc++)
 		argv[argc] = save_argv[argc];

--- a/smtpd/smtpd.h
+++ b/smtpd/smtpd.h
@@ -1529,7 +1529,7 @@ int session_socket_error(int);
 int getmailname(char *, size_t);
 int base64_encode(unsigned char const *, size_t, char *, size_t);
 int base64_decode(char const *, unsigned char *, size_t);
-int xclosefrom(int);
+void xclosefrom(int);
 
 /* waitq.c */
 int  waitq_wait(void *, void (*)(void *, void *, void *), void *);

--- a/smtpd/smtpd.h
+++ b/smtpd/smtpd.h
@@ -1529,7 +1529,7 @@ int session_socket_error(int);
 int getmailname(char *, size_t);
 int base64_encode(unsigned char const *, size_t, char *, size_t);
 int base64_decode(char const *, unsigned char *, size_t);
-
+int xclosefrom(int);
 
 /* waitq.c */
 int  waitq_wait(void *, void (*)(void *, void *, void *), void *);

--- a/smtpd/util.c
+++ b/smtpd/util.c
@@ -817,3 +817,15 @@ base64_decode(char const *src, unsigned char *dest, size_t destsize)
 {
 	return __b64_pton(src, dest, destsize);
 }
+
+int
+xclosefrom(int lowfd)
+{
+#if !defined HAVE_CLOSEFROM_INT
+    closefrom(lowfd);
+    return 0;
+#else
+    return closefrom(lowfd);
+#endif
+}
+

--- a/smtpd/util.c
+++ b/smtpd/util.c
@@ -818,14 +818,14 @@ base64_decode(char const *src, unsigned char *dest, size_t destsize)
 	return __b64_pton(src, dest, destsize);
 }
 
-int
+void
 xclosefrom(int lowfd)
 {
-#if !defined HAVE_CLOSEFROM_INT
-    closefrom(lowfd);
-    return 0;
+#if defined HAVE_CLOSEFROM_INT
+    if (closefrom(lowfd) == -1)
+        err(1, "closefrom");
 #else
-    return closefrom(lowfd);
+    closefrom(lowfd);
 #endif
 }
 


### PR DESCRIPTION
On Solaris and FreeBSD, closefrom return void. On this systems, the following code is invalid:

if (closefrom(4) == -1)

This patches fix it (inspired by __gilles@)