### PR TITLE
fix LOG_PERROR if not exists

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -362,6 +362,10 @@ AC_CHECK_DECLS([writev], [], [], [
 #include <unistd.h>
 ])
 
+AC_CHECK_DECLS([LOG_PERROR], [], [], [
+#include <syslog.h>
+])
+
 
 #
 # CHECKS FOR COMPILER CHARACTERISTICS

--- a/openbsd-compat/defines.h
+++ b/openbsd-compat/defines.h
@@ -512,4 +512,8 @@ typedef uint16_t	in_port_t;
 #define LOCK_UN         0x08            /* unlock file */
 #endif
 
+#if !HAVE_DECL_LOG_PERROR
+#define LOG_PERROR 0
+#endif
+
 #endif /* _DEFINES_H */


### PR DESCRIPTION
On some Os (Solaris, IllumOS ...) LOG_PERROR does not exists.
Using as bitmask, 0 seems to be a safe value.