### PR TITLE
Remove errc

### DIFF
--- a/openbsd-compat/Makefile.am
+++ b/openbsd-compat/Makefile.am
@@ -3,7 +3,7 @@ noinst_LIBRARIES = libopenbsd-compat.a
 libopenbsd_compat_a_SOURCES =							\
 		arc4random.c base64.c 		\
 		bsd-getpeereid.c bsd-misc.c bsd-waitpid.c 	\
-		entropy.c errc.c event_asr_run.c explicit_bzero.c	\
+		entropy.c event_asr_run.c explicit_bzero.c	\
 		fgetln.c getopt.c imsg.c imsg-buffer.c	\
 		libressl.c pidfile.c pw_dup.c reallocarray.c setresguid.c	\
 		setproctitle.c strlcat.c strlcpy.c strmode.c strtonum.c		\

--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -204,10 +204,6 @@ struct passwd *pw_dup(const struct passwd *);
 void *reallocarray(void *, size_t, size_t);
 #endif
 
-#ifndef HAVE_ERRC
-void errc(int, int, const char *, ...);
-#endif
-
 #ifndef HAVE_PLEDGE
 #define pledge(promises, paths) 0
 #endif

--- a/smtpd/enqueue.c
+++ b/smtpd/enqueue.c
@@ -278,7 +278,7 @@ enqueue(int argc, char *argv[], FILE *ofp)
 			unlink(sfn);
 			close(fd);
 		}
-		errc(EX_UNAVAILABLE, saved_errno, "mkstemp");
+		errx(EX_UNAVAILABLE, "mkstemp: %s", strerror(saved_errno));
 	}
 	unlink(sfn);
 	msg.noheader = parse_message(stdin, fake_from == NULL, tflag, fp);

--- a/smtpd/smtpctl.c
+++ b/smtpd/smtpctl.c
@@ -1296,7 +1296,7 @@ display(const char *s)
 				unlink(sfn);
 				close(fd);
 			}
-			errc(1, saved_errno, "mkstemp");
+			errx(1, "mkstemp: %s", strerror(saved_errno));
 		}
 		unlink(sfn);
 


### PR DESCRIPTION
errc is used only twice. Replace with errx.
openbsd-compat/errc.c is *NOT* removed by this PR