### PR TITLE
fix compatibility with libressl

### DIFF
--- a/openbsd-compat/defines.h
+++ b/openbsd-compat/defines.h
@@ -422,15 +422,6 @@ typedef uint16_t	in_port_t;
 #define INET6_ADDRSTRLEN 46
 #endif
 
-/*
- * Platforms that have arc4random_uniform() and not arc4random_stir()
- * shouldn't need the latter.
- */
-#if defined(HAVE_ARC4RANDOM) && defined(HAVE_ARC4RANDOM_UNIFORM) && \
-    !defined(HAVE_ARC4RANDOM_STIR)
-# define arc4random_stir()
-#endif
-
 #ifndef HAVE_VA_COPY
 # ifdef HAVE___VA_COPY
 #  define va_copy(dest, src) __va_copy(dest, src)

--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -119,20 +119,25 @@ int	BSDoptind;		/* index into parent argv vector */
 int getpeereid(int , uid_t *, gid_t *);
 #endif 
 
-#ifdef HAVE_ARC4RANDOM
-# ifndef HAVE_ARC4RANDOM_STIR
-#  define arc4random_stir()
-# endif
-#else
+#if !defined(HAVE_ARC4RANDOM) || defined(LIBRESSL_VERSION_NUMBER)
 unsigned int arc4random(void);
-void arc4random_stir(void);
-#endif /* !HAVE_ARC4RANDOM */
+#endif
 
-#ifndef HAVE_ARC4RANDOM_BUF
+#if defined(HAVE_ARC4RANDOM_STIR)
+void arc4random_stir(void);
+#elif defined(HAVE_ARC4RANDOM) || defined(LIBRESSL_VERSION_NUMBER)
+/* Recent system/libressl implementation; no need for explicit stir */
+# define arc4random_stir()
+#else
+/* openbsd-compat/arc4random.c provides arc4random_stir() */
+void arc4random_stir(void);
+#endif
+
+#if !defined(HAVE_ARC4RANDOM_BUF) || defined(LIBRESSL_VERSION_NUMBER)
 void arc4random_buf(void *, size_t);
 #endif
 
-#ifndef HAVE_ARC4RANDOM_UNIFORM
+#if !defined(HAVE_ARC4RANDOM_UNIFORM) || defined(LIBRESSL_VERSION_NUMBER)
 uint32_t arc4random_uniform(uint32_t);
 #endif
 
@@ -174,7 +179,7 @@ int vasprintf(char **, const char *, va_list);
 int vsnprintf(char *, size_t, const char *, va_list);
 #endif
 
-#ifndef HAVE_EXPLICIT_BZERO
+#if !defined(HAVE_EXPLICIT_BZERO) || defined(LIBRESSL_VERSION_NUMBER)
 void explicit_bzero(void *p, size_t n);
 #endif
 
@@ -200,7 +205,7 @@ int pidfile(const char *basename);
 struct passwd *pw_dup(const struct passwd *);
 #endif
 
-#ifndef HAVE_REALLOCARRAY
+#if !defined(HAVE_REALLOCARRAY) || defined(LIBRESSL_VERSION_NUMBER)
 void *reallocarray(void *, size_t, size_t);
 #endif
 


### PR DESCRIPTION
These functions are exported by libcrypto from libressl, due to its
similar OpenBSD compatibility layer, but they are not present in any
header files. Thus, while we can use the existing compiled function,
and do not need to provide our own, we do need to provide the prototype
for it.

This avoids implicit function declarations and the resulting crashes due
to pointer truncation.

The patch is based on an equivalent patch for OpenSSH from
https://bugzilla.mindrot.org/show_bug.cgi?id=2465
Also see
https://github.com/libressl-portable/portable/issues/109

Fixes #691