### PR TITLE
fix musl compatibility (missing function prototypes)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -594,6 +594,7 @@ AC_CHECK_FUNCS([ \
 	pledge \
 	pw_dup \
 	reallocarray \
+	res_hnok \
 	setenv \
 	setlinebuf \
 	setproctitle \

--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -208,8 +208,16 @@ void *reallocarray(void *, size_t, size_t);
 void errc(int, int, const char *, ...);
 #endif
 
+#ifndef HAVE_INET_NET_PTON
+int inet_net_pton(int, const char *, void *, size_t);
+#endif
+
 #ifndef HAVE_PLEDGE
 #define pledge(promises, paths) 0
+#endif
+
+#ifndef HAVE_RES_HNOK
+int res_hnok(const char *);
 #endif
 
 #if !HAVE_DECL_AF_LOCAL


### PR DESCRIPTION
inet_net_pton is already compiled, but no prototype is provided.
res_hnok is provided by the compatibility layer in libasr.

These fixes avoid warnings about implicit function declaration.

Fixes #758