### PR TITLE
fix __progname detection/use

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1511,7 +1511,7 @@ if test "x$ac_cv_have_control_in_msghdr" = "xyes"; then
 fi
 
 AC_CACHE_CHECK([if libc defines __progname], ac_cv_libc_defines___progname, [
-	AC_LINK_IFELSE([AC_LANG_PROGRAM([[]],
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[ #include <stdio.h> ]],
 		[[ extern char *__progname; printf("%s", __progname); ]])],
 	[ ac_cv_libc_defines___progname="yes" ],
 	[ ac_cv_libc_defines___progname="no" 

--- a/smtpd/smtpctl.c
+++ b/smtpd/smtpctl.c
@@ -1041,6 +1041,8 @@ main(int argc, char **argv)
 	gid_t		 gid;
 	char		*argv_mailq[] = { "show", "queue", NULL };
 
+	__progname = ssh_get_progname(argv[0]);
+
 	sendmail_compat(argc, argv);
 	if (geteuid())
 		errx(1, "need root privileges");


### PR DESCRIPTION
Fix warning when check for __progname in configure.ac

Fix segfault when using undefined var in smtpctl.c