### PR TITLE
Fix table_dump_lookup's default case

### DIFF
--- a/smtpd/table.c
+++ b/smtpd/table.c
@@ -702,6 +702,7 @@ table_dump_lookup(enum table_service s, union lookup *lk)
 		break;
 
 	default:
+		strlcpy(buf, "???", sizeof(buf));
 		break;
 	}
 


### PR DESCRIPTION
Right now, if table_dump_lookup is called with a lookup type it cannot handle, eg. K_MADDRMAP,
it will return its static buffer with the contents from previous lookup, which can be very confusing, eg. when I see in the logs a senders table returning a password hash.

This PR fixes it by writing `"???"` to the buffer in the type switch reaches `default`