### PR TITLE
Add K_MAILADDRMAP support to table_dump_lookup

### DIFF
--- a/smtpd/table.c
+++ b/smtpd/table.c
@@ -696,6 +696,7 @@ table_dump_lookup(enum table_service s, union lookup *lk)
 		break;
 
 	case K_MAILADDRMAP:
+		buf[0] = '\0';
 		TAILQ_FOREACH(mn, &lk->maddrmap->queue, entries) {
 			(void)strlcat(buf, mn->mailaddr.user, sizeof(buf));
 			(void)strlcat(buf, "@", sizeof(buf));

--- a/smtpd/table.c
+++ b/smtpd/table.c
@@ -638,8 +638,8 @@ static const char *
 table_dump_lookup(enum table_service s, union lookup *lk)
 {
 	static char		buf[LINE_MAX];
-	int			ret;
 	struct maddrnode       *mn;
+	int			ret;
 
 	switch (s) {
 	case K_NONE:
@@ -697,13 +697,12 @@ table_dump_lookup(enum table_service s, union lookup *lk)
 
 	case K_MAILADDRMAP:
 		TAILQ_FOREACH(mn, &lk->maddrmap->queue, entries) {
-			if (strlcat(buf, mn->mailaddr.user, sizeof(buf)) >= sizeof(buf)
-			 || strlcat(buf, "@", sizeof(buf)) >= sizeof(buf)
-			 || strlcat(buf, mn->mailaddr.domain, sizeof(buf)) >= sizeof(buf)
-			 || strlcat(buf, ", ", sizeof(buf)) >= sizeof(buf)
-			) {
-			    strlcpy(buf + sizeof(buf) - 4, "...", 4);
-			    break;
+			(void)strlcat(buf, mn->mailaddr.user, sizeof(buf));
+			(void)strlcat(buf, "@", sizeof(buf));
+			(void)strlcat(buf, mn->mailaddr.domain, sizeof(buf));
+			if (strlcat(buf, ", ", sizeof(buf)) >= sizeof(buf)) {
+				strlcpy(buf + sizeof(buf) - 4, "...", 4);
+				break;
 			}
 		}
 		break;

--- a/smtpd/table.c
+++ b/smtpd/table.c
@@ -699,8 +699,12 @@ table_dump_lookup(enum table_service s, union lookup *lk)
 		TAILQ_FOREACH(mn, &lk->maddrmap->queue, entries) {
 			(void)strlcat(buf, mn->mailaddr.user, sizeof(buf));
 			(void)strlcat(buf, "@", sizeof(buf));
-			(void)strlcat(buf, mn->mailaddr.domain, sizeof(buf));
-			if (strlcat(buf, ", ", sizeof(buf)) >= sizeof(buf)) {
+			ret = strlcat(buf, mn->mailaddr.domain, sizeof(buf));
+
+			if (mn != TAILQ_LAST(&lk->maddrmap->queue, xmaddr))
+				ret = strlcat(buf, ", ", sizeof(buf));
+
+			if (ret >= sizeof(buf)) {
 				strlcpy(buf + sizeof(buf) - 4, "...", 4);
 				break;
 			}

--- a/smtpd/table.c
+++ b/smtpd/table.c
@@ -639,7 +639,6 @@ table_dump_lookup(enum table_service s, union lookup *lk)
 {
 	static char		buf[LINE_MAX];
 	int			ret;
-	size_t			written;
 	struct maddrnode       *mn;
 
 	switch (s) {
@@ -697,19 +696,14 @@ table_dump_lookup(enum table_service s, union lookup *lk)
 		break;
 
 	case K_MAILADDRMAP:
-		written = 0;
 		TAILQ_FOREACH(mn, &lk->maddrmap->queue, entries) {
-			ret = snprintf(&buf[written], sizeof(buf) - written,
-			    "%s@%s, ",
-			    mn->mailaddr.user,
-			    mn->mailaddr.domain);
-			if (ret < 0)
-				goto err;
-			written += ret;
-			if  (written >= sizeof (buf)) {
-				written = sizeof(buf) - 4;
-				(void)strlcpy(&buf[written], "...",
-				    sizeof(buf) - written);
+			if (strlcat(buf, mn->mailaddr.user, sizeof(buf)) >= sizeof(buf)
+			 || strlcat(buf, "@", sizeof(buf)) >= sizeof(buf)
+			 || strlcat(buf, mn->mailaddr.domain, sizeof(buf)) >= sizeof(buf)
+			 || strlcat(buf, ", ", sizeof(buf)) >= sizeof(buf)
+			) {
+			    strlcpy(buf + sizeof(buf) - 4, "...", 4);
+			    break;
 			}
 		}
 		break;


### PR DESCRIPTION
If there's too many addresses to fit in a line (because eg. someone didn't use whitespace in the table), the code puts "..."  at the end of the truncated string.

(in response to #780)