### PR TITLE
defines.h: Add openbsd-compat define for CLOCK_REALTIME

### DIFF
--- a/openbsd-compat/defines.h
+++ b/openbsd-compat/defines.h
@@ -475,6 +475,10 @@ typedef uint16_t	in_port_t;
 #ifndef CLOCK_MONOTONIC
 #define CLOCK_MONOTONIC -1
 #endif
+
+#ifndef CLOCK_REALTIME
+#define CLOCK_REALTIME -2
+#endif
 /* end of chl */
 
 #ifndef HAVE_FPARSELN


### PR DESCRIPTION
MacOS 10.10 does not implement clock_gettime(), and so is missing the defines
for CLOCK_REALTIME and CLOCK_MONOTONIC. A definition exists for CLOCK_MONOTONIC
in openbsd-compat , but CLOCK_REALTIME was missing.

    ../../smtpd/queue_fs.c:763:20: error: use of undeclared identifier 'CLOCK_REALTIME'
            if (clock_gettime(CLOCK_REALTIME, &startup))
                              ^
    1 error generated.
    make[3]: *** [../../smtpd/smtpd-queue_fs.o] Error 1