### PR TITLE
Fix Message-Id header not added if missing and listener port is 587

### DIFF
--- a/smtpd/smtp_session.c
+++ b/smtpd/smtp_session.c
@@ -1156,7 +1156,7 @@ smtp_tx(struct smtp_session *s)
 	rfc2822_body_callback(&tx->rfc2822_parser,
 	    dataline_callback, s);
 
-	if (s->listener->local || s->listener->port == 587) {
+	if (s->listener->local || ntohs(s->listener->port) == 587) {
 		rfc2822_missing_header_callback(&tx->rfc2822_parser, "date",
 		    header_missing_callback, s);
 		rfc2822_missing_header_callback(&tx->rfc2822_parser, "message-id",


### PR DESCRIPTION
#814 suggests two possible fixes, this PR covers the first suggestion (smallest change to existing code).