### PR TITLE
Fixing support for RFC4954 AUTH LOGIN initial-response

### DIFF
--- a/smtpd/smtp_session.c
+++ b/smtpd/smtp_session.c
@@ -1686,6 +1686,10 @@ smtp_rfc4954_auth_login(struct smtp_session *s, char *arg)
 	switch (s->state) {
 	case STATE_HELO:
 		smtp_enter_state(s, STATE_AUTH_USERNAME);
+		if (strchr(arg, '') != NULL) {
+			smtp_rfc4954_auth_login(s, arg);
+			return;
+		}
 		smtp_reply(s, "334 VXNlcm5hbWU6");
 		return;
 

--- a/smtpd/smtp_session.c
+++ b/smtpd/smtp_session.c
@@ -1686,7 +1686,7 @@ smtp_rfc4954_auth_login(struct smtp_session *s, char *arg)
 	switch (s->state) {
 	case STATE_HELO:
 		smtp_enter_state(s, STATE_AUTH_USERNAME);
-		if (strchr(arg, '') != NULL) {
+		if (strchr(arg, '\0') != NULL) {
 			smtp_rfc4954_auth_login(s, arg);
 			return;
 		}


### PR DESCRIPTION
Due to RFC4954 the "AUTH LOGIN" smtp command can be used with username as initial response. In this case the state should change to:
https://github.com/OpenSMTPD/OpenSMTPD/blob/4d34dfe9cffe5683574342d7bbef6a7c9de00e11/smtpd/smtp_session.c#L1688

and return without doing:

https://github.com/OpenSMTPD/OpenSMTPD/blob/4d34dfe9cffe5683574342d7bbef6a7c9de00e11/smtpd/smtp_session.c#L1689

In my opinion there should be something like:

```
smtp_enter_state(s, STATE_AUTH_USERNAME); 
if (strchr(arg, '\0') != NULL) {
    smtp_rfc4954_auth_login(s, arg);
    return;
}
smtp_reply(s, "334 VXNlcm5hbWU6"); 
```
In 2014 there was an accepted pull request already: https://github.com/OpenSMTPD/OpenSMTPD/pull/425. But it is not existent in master anymore.

I already opened an issue here: https://github.com/OpenSMTPD/OpenSMTPD/issues/819