### PR TITLE
crypt_checkpass: include HAVE_CRYPT_H definition, add NULL check

### DIFF
--- a/openbsd-compat/crypt_checkpass.c
+++ b/openbsd-compat/crypt_checkpass.c
@@ -1,5 +1,6 @@
 /* OPENBSD ORIGINAL: lib/libc/crypt/cryptutil.c */
 
+#include "includes.h"
 #include <errno.h>
 #ifdef HAVE_CRYPT_H
 #include <crypt.h>
@@ -10,6 +11,8 @@
 int
 crypt_checkpass(const char *pass, const char *goodhash)
 {
+	char *c;
+
 	if (goodhash == NULL)
 		goto fail;
 
@@ -17,7 +20,11 @@ crypt_checkpass(const char *pass, const char *goodhash)
 	if (strlen(goodhash) == 0 && strlen(pass) == 0)
 		return 0;
 
-	if (strcmp(crypt(pass, goodhash), goodhash) == 0)
+	c = crypt(pass, goodhash);
+	if (c == NULL)
+		goto fail;
+
+	if (strcmp(c, goodhash) == 0)
 		return 0;
 
 fail:


### PR DESCRIPTION
adding `#include "includes.h"` makes sure, `HAVE_CRYPT_H` is defined if detected by the configure script. This fixes #833.

`crypt(3)` might return `NULL` on error, this should not be passed to `strcmp(3)`