### PR TITLE
add brackets around Return-Path as per RFC5322 §3.6.6

### DIFF
--- a/smtpd/mda.c
+++ b/smtpd/mda.c
@@ -266,7 +266,7 @@ mda_imsg(struct mproc *p, struct imsg *imsg)
 				 * if any
 				 */
 				n = io_printf(s->io,
-				    "Return-Path: %s\n"
+				    "Return-Path: <%s>\n"
 				    "Delivered-To: %s\n",
 				    e->sender,
 				    e->rcpt ? e->rcpt : e->dest);


### PR DESCRIPTION
The absence of <> breaks LDA with the dovecot 2.3.0.1 -> 2.3.1 upgrade, even though dovecot developers have told me it'll be made more lenient in the next update.

This should fix the RFC-non-compliance from OpenSMTPD side. :)

Thanks for your work, as always!