### PR TITLE
Split openbsd compat

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,7 +147,7 @@ AC_CHECK_HEADERS([ \
 ])
 
 AM_CONDITIONAL([SUPPORT_ERR_H], [test x$HAVE_ERR_H = x1])
-AM_CONDITIONAL([SUPPORT_PATHS_H], [test x$HAVE_ERR_H = x1])
+AM_CONDITIONAL([SUPPORT_PATHS_H], [test x$HAVE_PATHS_H = x1])
 
 # NetBSD requires sys/types.h before login_cap.h
 AC_CHECK_HEADERS([login_cap.h], [], [], [

--- a/configure.ac
+++ b/configure.ac
@@ -146,6 +146,9 @@ AC_CHECK_HEADERS([ \
 	vis.h
 ])
 
+AM_CONDITIONAL([SUPPORT_ERR_H], [test x$HAVE_ERR_H = x1])
+AM_CONDITIONAL([SUPPORT_PATHS_H], [test x$HAVE_ERR_H = x1])
+
 # NetBSD requires sys/types.h before login_cap.h
 AC_CHECK_HEADERS([login_cap.h], [], [], [
 #include <sys/types.h>

--- a/mk/mail/mail.lmtp/Makefile.am
+++ b/mk/mail/mail.lmtp/Makefile.am
@@ -7,6 +7,9 @@ mail_lmtp_SOURCES+= $(smtpd_srcdir)/log.c
 
 AM_CPPFLAGS=		-I$(top_srcdir)/smtpd			\
 			-I$(top_srcdir)/openbsd-compat
+if !SUPPORT_ERR_H
+AM_CPPFLAGS += -I$(top_srcdir)/openbsd-compat/err_h
+endif
 
 LIBCOMPAT =		$(top_builddir)/openbsd-compat/libopenbsd-compat.a
 

--- a/mk/mail/mail.maildir/Makefile.am
+++ b/mk/mail/mail.maildir/Makefile.am
@@ -7,6 +7,9 @@ mail_maildir_SOURCES+= $(smtpd_srcdir)/log.c
 
 AM_CPPFLAGS=		-I$(top_srcdir)/smtpd			\
 			-I$(top_srcdir)/openbsd-compat
+if !SUPPORT_ERR_H
+AM_CPPFLAGS += -I$(top_srcdir)/openbsd-compat/err_h
+endif
 
 LIBCOMPAT =		$(top_builddir)/openbsd-compat/libopenbsd-compat.a
 

--- a/mk/mail/mail.mda/Makefile.am
+++ b/mk/mail/mail.mda/Makefile.am
@@ -7,6 +7,9 @@ mail_mda_SOURCES+= $(smtpd_srcdir)/log.c
 
 AM_CPPFLAGS=		-I$(top_srcdir)/smtpd			\
 			-I$(top_srcdir)/openbsd-compat
+if !SUPPORT_ERR_H
+AM_CPPFLAGS += -I$(top_srcdir)/openbsd-compat/err_h
+endif
 
 LIBCOMPAT =		$(top_builddir)/openbsd-compat/libopenbsd-compat.a
 

--- a/mk/smtpctl/Makefile.am
+++ b/mk/smtpctl/Makefile.am
@@ -41,6 +41,9 @@ smtpctl_CFLAGS+=	-DPATH_GZCAT=\"$(ZCAT)\" \
 
 AM_CPPFLAGS=		-I$(top_srcdir)/smtpd			\
 			-I$(top_srcdir)/openbsd-compat
+if !SUPPORT_ERR_H
+AM_CPPFLAGS += -I$(top_srcdir)/openbsd-compat/err_h
+endif
 
 LIBCOMPAT=		$(top_builddir)/openbsd-compat/libopenbsd-compat.a
 

--- a/mk/smtpd/Makefile.am
+++ b/mk/smtpd/Makefile.am
@@ -89,6 +89,12 @@ smtpd_CFLAGS+=		-DCA_FILE=\"$(CA_FILE)\"
 
 AM_CPPFLAGS=		-I$(smtpd_srcdir)	\
 			-I$(compat_srcdir)
+if !SUPPORT_ERR_H
+AM_CPPFLAGS += -I$(top_srcdir)/openbsd-compat/err_h
+endif
+if !SUPPORT_PATHS_H
+AM_CPPFLAGS += -I$(top_srcdir)/openbsd-compat/paths_h
+endif
 
 LIBCOMPAT=		$(top_builddir)/openbsd-compat/libopenbsd-compat.a
 

--- a/openbsd-compat/Makefile.am
+++ b/openbsd-compat/Makefile.am
@@ -6,7 +6,6 @@ libopenbsd_compat_a_SOURCES +=	bsd-getpeereid.c
 libopenbsd_compat_a_SOURCES +=	bsd-misc.c
 libopenbsd_compat_a_SOURCES +=	bsd-waitpid.c
 libopenbsd_compat_a_SOURCES +=	entropy.c
-libopenbsd_compat_a_SOURCES +=	errc.c
 libopenbsd_compat_a_SOURCES +=	event_asr_run.c
 libopenbsd_compat_a_SOURCES +=	fgetln.c
 libopenbsd_compat_a_SOURCES +=	freezero.c
@@ -50,6 +49,10 @@ endif
 
 if !SUPPORT_DIRNAME
 libopenbsd_compat_a_SOURCES += dirname.c
+endif
+
+if !SUPPORT_ERR_H
+libopenbsd_compat_a_SOURCES += bsd-err.c
 endif
 
 if !SUPPORT_ERRC
@@ -96,3 +99,6 @@ EXTRA_DIST +=	bsd-vis.h
 EXTRA_DIST +=	xmalloc.h
 
 AM_CPPFLAGS = -I$(top_srcdir)/smtpd -I$(top_srcdir)/openbsd-compat
+if !SUPPORT_ERR_H
+AM_CPPFLAGS += -I$(top_srcdir)/openbsd-compat/err_h
+endif

--- a/openbsd-compat/err_h/err.h
+++ b/openbsd-compat/err_h/err.h
@@ -1,0 +1,14 @@
+#ifndef ERR_H
+#define ERR_H
+
+#ifndef LIBCRYPTOCOMPAT_ERR_H
+#define LIBCRYPTOCOMPAT_ERR_H
+
+void err(int, const char *, ...);
+void errx(int, const char *, ...);
+void warn(const char *, ...);
+void warnx(const char *, ...);
+
+#endif
+
+#endif

--- a/openbsd-compat/paths_h/paths.h
+++ b/openbsd-compat/paths_h/paths.h
@@ -1,0 +1,8 @@
+#ifndef PATHS_H
+#define PATHS_H
+
+#ifndef _PATH_DEFPATH
+#define _PATH_DEFPATH "/bin:/usr/bin"
+#endif
+
+#endif

--- a/openbsd-compat/xmalloc.c
+++ b/openbsd-compat/xmalloc.c
@@ -15,11 +15,7 @@
 
 #include "includes.h"
 
-#ifdef HAVE_ERR_H
 #include <err.h>
-#else
-#include "bsd-err.h"
-#endif
 #include <limits.h>
 #include <stdarg.h>
 #include <stdio.h>


### PR DESCRIPTION
start split of openbsd-compat

build fine on Solaris who's don't provide err.h nor paths.h