### PR TITLE
minor linux portability fixes

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -36,7 +36,7 @@ aclocalflags="`sed -ne 's/^[ \t]*ACLOCAL_AMFLAGS[ \t]*=//p' Makefile.am 2>/dev/n
 
 # Check for automake
 amvers="no"
-for v in 15 14; do
+for v in 16 15 14; do
   if automake-1.${v} --version >/dev/null 2>&1; then
     amvers="-1.${v}"
     break

--- a/configure.ac
+++ b/configure.ac
@@ -137,7 +137,6 @@ AC_CHECK_HEADERS([ \
 	sys/cdefs.h \
 	sys/dir.h \
 	sys/file.h \
-	sys/mount.h \
 	sys/ndir.h \
 	sys/pstat.h \
 	sys/statfs.h \
@@ -357,6 +356,16 @@ AC_CHECK_DECLS([O_NONBLOCK], [], [], [
 #endif
 ])
 
+AC_CHECK_DECLS([O_EXCL], [], [], [
+#include <sys/types.h>
+#ifdef HAVE_SYS_STAT_H
+# include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+# include <fcntl.h>
+#endif
+])
+
 AC_CHECK_DECLS([AF_LOCAL, PF_LOCAL], [], [], [
 #include <sys/socket.h>
 ])
@@ -375,6 +384,11 @@ AC_CHECK_DECLS([LOG_PERROR], [], [], [
 #include <syslog.h>
 ])
 
+AC_CHECK_DECLS([EFTYPE], [], [
+	AC_MSG_ERROR([please define EFTYPE, by e.g. passing -DEFTYPE=EMEDIUMTYPE in your CFLAGS])
+], [
+#include <errno.h>
+])
 
 #
 # CHECKS FOR COMPILER CHARACTERISTICS


### PR DESCRIPTION
Linux/glibc does not have O_EXCL for open, sockaddr.sa_len,
sockaddr_storage.ss_len or the EFTYPE errno.

Use autoconf macros to conditionally compile replacements.

If EFTYPE is unavailable, replace it with EMEDIUMTYPE which seems to be
the closest.

Also check for automake 16.

These changes were necessary for OpenSuse Tumbleweed, these changes
should also apply to many other distributions.

We are running this code for a server and it seems to be working
correctly.

If, for the sake of de-uglification, you would like to just use the more
portable code for any of these changes without the conditional
compilation, I would be happy to make this change.