### PR TITLE
Output "configuration ok"-message on standard output

### DIFF
--- a/smtpd/smtpd.c
+++ b/smtpd/smtpd.c
@@ -660,7 +660,7 @@ main(int argc, char *argv[])
 #endif
 		load_pki_tree();
 		load_pki_keys();
-		fprintf(stderr, "configuration OK\n");
+		printf("configuration OK\n");
 		exit(0);
 	}
 


### PR DESCRIPTION
Instead of standard error (which can be quite annoying when simply
running `smtpd -n`). This change makes it easy to silence this messages,
e.g. when verbose output is not needed, by simply redirecting standard
output to `/dev/null`.

Discussion: I believe that this message is not needed at all since the
exit status already indicates whether the configuration is ok.