### PR TITLE
bootstrap: allow automake 1.16

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -36,7 +36,7 @@ aclocalflags="`sed -ne 's/^[ \t]*ACLOCAL_AMFLAGS[ \t]*=//p' Makefile.am 2>/dev/n
 
 # Check for automake
 amvers="no"
-for v in 15 14; do
+for v in 16 15 14; do
   if automake-1.${v} --version >/dev/null 2>&1; then
     amvers="-1.${v}"
     break


### PR DESCRIPTION
This change allows running `bootstrap` with `automake-1.16`, which appears to allow successful building (provided the right changes are made, cf. message just below)