### PR TITLE
Add missing object file for smtpctl

### DIFF
--- a/mk/smtpctl/Makefile.am
+++ b/mk/smtpctl/Makefile.am
@@ -4,6 +4,7 @@ sbin_PROGRAMS=		smtpctl
 
 smtpctl_SOURCES=	$(smtpd_srcdir)/enqueue.c
 smtpctl_SOURCES+=	$(smtpd_srcdir)/parser.c
+smtpctl_SOURCES+=	$(smtpd_srcdir)/config.c
 smtpctl_SOURCES+=	$(smtpd_srcdir)/log.c
 smtpctl_SOURCES+=	$(smtpd_srcdir)/envelope.c
 smtpctl_SOURCES+=	$(smtpd_srcdir)/queue_backend.c


### PR DESCRIPTION
With this change and addition of `CFLAGS=-ffunction-sections` and
`LDFLAGS=-Wl,--gc-sections`, it now builds.

`purge_config` is defined in `config.c` but used in `parse.y`, making
`config.c` mandatory. But `config.c` requires lots of functions from
other files in other unrelated functions, meaning that these unrelated
(and unused in `smtpctl`) functions need to be garbage-collected.

This is a workaround, a better way would likely be to refactor
`purge_config` and `config_default` out of `config.c`, but I don't want
to push for a change that would separate the portable version and the
OpenBSD version too much.