### PR TITLE
fix cross compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1363,6 +1363,9 @@ exit(-1);
 	],
 	[
 		AC_MSG_RESULT([$piddir from default value])
+	],
+	[
+		AC_MSG_RESULT([$piddir from default value])
 	]
 )
 


### PR DESCRIPTION
AC_RUN_IFELSE is missing the last argument [action-if-cross-compiling]

See also: https://www.gnu.org/software/autoconf/manual/autoconf-2.68/html_node/Runtime.html