### PR TITLE
Allow to check user credentials in the table backend

### DIFF
--- a/smtpd/smtpd-api.h
+++ b/smtpd/smtpd-api.h
@@ -122,21 +122,22 @@ struct table_open_params {
 };
 
 enum table_service {
-	K_NONE		= 0x000,
-	K_ALIAS		= 0x001,	/* returns struct expand	*/
-	K_DOMAIN	= 0x002,	/* returns struct destination	*/
-	K_CREDENTIALS	= 0x004,	/* returns struct credentials	*/
-	K_NETADDR	= 0x008,	/* returns struct netaddr	*/
-	K_USERINFO	= 0x010,	/* returns struct userinfo	*/
-	K_SOURCE	= 0x020,	/* returns struct source	*/
-	K_MAILADDR	= 0x040,	/* returns struct mailaddr	*/
-	K_ADDRNAME	= 0x080,	/* returns struct addrname	*/
-	K_MAILADDRMAP	= 0x100,	/* returns struct maddrmap	*/
-	K_RELAYHOST	= 0x200,	/* returns struct relayhost	*/
-	K_STRING	= 0x400,
-	K_REGEX		= 0x800,
+	K_NONE		= 0x0000,
+	K_ALIAS		= 0x0001,	/* returns struct expand	*/
+	K_DOMAIN	= 0x0002,	/* returns struct destination	*/
+	K_CREDENTIALS	= 0x0004,	/* returns struct credentials	*/
+	K_NETADDR	= 0x0008,	/* returns struct netaddr	*/
+	K_USERINFO	= 0x0010,	/* returns struct userinfo	*/
+	K_SOURCE	= 0x0020,	/* returns struct source	*/
+	K_MAILADDR	= 0x0040,	/* returns struct mailaddr	*/
+	K_ADDRNAME	= 0x0080,	/* returns struct addrname	*/
+	K_MAILADDRMAP	= 0x0100,	/* returns struct maddrmap	*/
+	K_RELAYHOST	= 0x0200,	/* returns struct relayhost	*/
+	K_STRING	= 0x0400,
+	K_REGEX		= 0x0800,
+	K_CHECKUSER	= 0x1000,	/* check user credentials	*/
 };
-#define K_ANY		  0xfff
+#define K_ANY		  0xffff
 
 enum {
 	PROC_TABLE_OK,


### PR DESCRIPTION
Some backend doesn't use crypt to store the passwords so we
cannot just fetch the password with K_CREDENTIALS because
it might be hashed with an unknown method. We need another
way to authenticate the user directly in the table backend.

- Introduce a new table service K_CHECKUSER which can be
  used to check the credentials in the table backend.
  The key must have the form "user:password".
- Make sure the key is never converted to lowercase when using
  K_CHECKUSER (we don't want the password to be converted to
  lowercase).
- When authenticating a new smtp session, first try to use
  K_CHECKUSER to authenticate using the backend, and then if
  it fails use K_CREDENTIALS and the crypt_checkpass(3) to keep
  backward compatibility.