### PR TITLE
Switch Dockerfile to using /etc/mail/ for all configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY . /opensmtpd
 #build opensmtpd
 RUN rm -r /usr/local/
 RUN ./bootstrap && \
-    ./configure --with-gnu-ld --sysconfdir=/etc --with-path-empty=/var/lib/opensmtpd/empty/ && \
+    ./configure --with-gnu-ld --sysconfdir=/etc/mail --with-path-empty=/var/lib/opensmtpd/empty/ && \
     make && \
     make install
 
@@ -36,6 +36,7 @@ EXPOSE 25
 EXPOSE 465
 EXPOSE 587
 
+VOLUME /etc/mail
 VOLUME /var/spool/smtpd
 WORKDIR /var/spool/smtpd
 
@@ -46,11 +47,12 @@ RUN apk add --no-cache libressl libevent libasr fts zlib ca-certificates && \
     mkdir -p /var/lib/opensmtpd/empty/ && \
     adduser _smtpd -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false && \
     adduser _smtpq -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false && \
+    mkdir -p /etc/mail/ && \
     mkdir -p /var/spool/smtpd
 
 COPY --from=build /usr/local/ /usr/local/
 
-COPY smtpd/smtpd.conf /etc/
+COPY smtpd/smtpd.conf /etc/mail
 
 #OpenSMTPD needs root permissions to open port 25.
 #It immediately changes to running as _smtpd after that.

--- a/README.md
+++ b/README.md
@@ -200,3 +200,20 @@ Then:
 or in debug and verbose mode
 
     smtpd -dv
+
+# Docker version
+
+OpenSMTPD provides a convenient docker file for getting started quickly.  However, there are a few minor quirks to know about.
+
+For ease of use, all configuration files live in '/etc/mail'.  This means the two files to modify are:
+
+	/etc/mail/smtpd.conf
+	/etc/mail/mailname
+
+Also, local deliveries are disabled by default.  The nature of Docker makes interacting with local users a bit tricky, and requires a user to know the ins and outs of Docker.
+
+
+To run the Docker version, create a '/etc/mail' directory, and add your own smtpd.conf file there.  Next, run:
+```
+docker run --name smtpd_server -p 25:25 -v /etc/mail:/etc/mail emperorarthur/opensmtpd
+```


### PR DESCRIPTION
Some versions of docker have problems mounting single files.
Also include directions for using it in the Readme.

Some of the man pages refer to '/etc/mail/smtpd.conf', others to '/etc/smtpd.conf', which is the program's default, and `./configure` defaults to '/usr/local/etc/smtpd.conf'. I'm using '/etc/smtpd/smtpd.conf' because many programs seem to use the smtpd folder.

If you'd like this in a different folder, for example '/etc/mail' it's an easy change.  However leaving the file in just '/etc' wasn't working with docker.