### PR TITLE
Add an automated test to check if TLS certificates work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 *.in
 *.out
 *.log
-*~
 .#*
 .deps
 m4
@@ -26,6 +25,8 @@ stamp-h1
 ylwrap
 tags
 obj
+
+#Other VCS files
 CVS/
 smtpd/CVS
 smtpd/smtpctl/CVS
@@ -34,3 +35,7 @@ smtpd/mail/CVS
 smtpd/mail/CVS
 smtpd/mail/*/CVS
 smtpd/smtpctl/CVS/*
+
+#Editor temporary files
+*~
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,9 @@ FROM alpine:3.9 as build
 
 WORKDIR /opensmtpd
 
+# libressl is used for testing only
 RUN apk add --no-cache \
     ca-certificates \
-    wget \
-    cmake \
     automake \
     autoconf \
     libtool \
@@ -18,7 +17,15 @@ RUN apk add --no-cache \
     libasr-dev \
     fts-dev \
     zlib-dev \
-    libressl-dev
+    libressl-dev \
+    libressl
+
+#For testing
+RUN mkdir -p /var/lib/opensmtpd/empty/ && \
+    adduser _smtpd -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false && \
+    adduser _smtpq -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false && \
+    mkdir -p /var/spool/smtpd && \
+    chmod 711 /var/spool/smtpd
 
 COPY . /opensmtpd
 
@@ -48,7 +55,8 @@ RUN apk add --no-cache libressl libevent libasr fts zlib ca-certificates && \
     adduser _smtpd -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false && \
     adduser _smtpq -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false && \
     mkdir -p /etc/mail/ && \
-    mkdir -p /var/spool/smtpd
+    mkdir -p /var/spool/smtpd && \
+    chmod 711 /var/spool/smtpd
 
 COPY --from=build /usr/local/ /usr/local/
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,6 @@
+sut:
+  build: .
+  #This means we are using the build container, not the final container
+  target: build
+  entrypoint: /bin/sh
+  command: /opensmtpd/tests/test_all.sh

--- a/tests/certificate_test/smtpd.conf
+++ b/tests/certificate_test/smtpd.conf
@@ -1,0 +1,13 @@
+pki_domain = "localhost"
+pki $pki_domain cert "/etc/ssl/private/sites/fullchain.cer"
+pki $pki_domain key "/etc/ssl/private/sites/site.key"
+
+#Encrypted password is "password"
+table passwords {"user"="$6$tf940h4BpywpeKID$pWYiqoWywVPybeHaEcqHSRBD/7UxBmYhx7iHvxj/B3LBxCWwnFx7.3JwMISsN9EpPMwEZELvbNehVLl0IvvZo/"}
+
+listen on localhost          tls         hostname $pki_domain pki $pki_domain auth-optional <passwords>
+listen on localhost port 465 smtps       hostname $pki_domain pki $pki_domain auth-optional <passwords>
+listen on localhost port 587 tls-require hostname $pki_domain pki $pki_domain auth          <passwords>
+
+action "local" maildir "/tmp/"
+match auth from any for any action "local"

--- a/tests/certificate_test/test.sh
+++ b/tests/certificate_test/test.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -euxo pipefail
+BASEDIR=$(dirname $0)
+
+# Setup TLS
+mkdir -p /etc/ssl/private/sites/
+openssl genrsa -out /etc/ssl/private/sites/site.key 4096
+openssl req -new -x509 -key /etc/ssl/private/sites/site.key -out /etc/ssl/private/sites/fullchain.cer -subj "/CN='localhost'"
+chmod 600 /etc/ssl/private/sites/site.key
+chmod 644 /etc/ssl/private/sites/fullchain.cer
+
+smtpd -dv -f "$BASEDIR/smtpd.conf" &
+
+#Wait for smtpd to be ready to receive connections
+sleep 3
+
+#OpenSSL is crazy and will treat a capital "R" or "Q" as a command without the -quiet flag
+#OpenSMTPD doesn't support pipelining, so wait 0.1 seconds between lines
+awk '{print $0; system("sleep .1");}' "$BASEDIR/../test_email.txt" | \
+    openssl s_client -quiet -connect localhost:25 -starttls smtp

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -euxo pipefail
+BASEDIR=$(dirname $0)
+
+echo "Testing TLS"
+"$BASEDIR/certificate_test/test.sh"

--- a/tests/test_email.txt
+++ b/tests/test_email.txt
@@ -1,0 +1,13 @@
+HELO localhost
+AUTH LOGIN
+dXNlcg==
+cGFzc3dvcmQ=
+MAIL FROM:<_smtpd@localhost>
+RCPT TO:<_smtpd@localhost>
+DATA
+Subject: Test Email
+
+It works
+
+.
+QUIT


### PR DESCRIPTION
This should allow Docker Hub to act as a CI platform.

NOTE:  This is testing for #908 which means Docker Hub's test should fail until it is resolved.