### PR TITLE
WIP: make paths and users configurable

### DIFF
--- a/smtpd/ca.c
+++ b/smtpd/ca.c
@@ -83,7 +83,7 @@ ca(void)
 	if ((pw = getpwnam(SMTPD_USER)) == NULL)
 		fatalx("unknown user " SMTPD_USER);
 
-	if (chroot(PATH_CHROOT) == -1)
+	if (chroot(env->sc_path_chroot) == -1)
 		fatal("ca: chroot");
 	if (chdir("/") == -1)
 		fatal("ca: chdir(\"/\")");

--- a/smtpd/ca.c
+++ b/smtpd/ca.c
@@ -80,8 +80,8 @@ ca(void)
 
 	purge_config(PURGE_LISTENERS|PURGE_TABLES|PURGE_RULES|PURGE_DISPATCHERS);
 
-	if ((pw = getpwnam(SMTPD_USER)) == NULL)
-		fatalx("unknown user " SMTPD_USER);
+	if ((pw = getpwnam(env->sc_smtpd_user)) == NULL)
+		fatalx("unknown user %s", env->sc_smtpd_user);
 
 	if (chroot(env->sc_path_chroot) == -1)
 		fatal("ca: chroot");

--- a/smtpd/config.c
+++ b/smtpd/config.c
@@ -61,6 +61,7 @@ config_default(void)
 
         conf->sc_sock_path = SMTPD_SOCKET;
         conf->sc_path_chroot = PATH_CHROOT;
+        conf->sc_smtpd_user = SMTPD_USER;
 	conf->sc_maxsize = DEFAULT_MAX_BODY_SIZE;
 	conf->sc_subaddressing_delim = SUBADDRESSING_DELIMITER;
 	conf->sc_ttl = SMTPD_QUEUE_EXPIRY;

--- a/smtpd/config.c
+++ b/smtpd/config.c
@@ -59,6 +59,7 @@ config_default(void)
 
 	(void)strlcpy(conf->sc_hostname, hostname, sizeof(conf->sc_hostname));
 
+        conf->sc_sock_path = SMTPD_SOCKET;
 	conf->sc_maxsize = DEFAULT_MAX_BODY_SIZE;
 	conf->sc_subaddressing_delim = SUBADDRESSING_DELIMITER;
 	conf->sc_ttl = SMTPD_QUEUE_EXPIRY;

--- a/smtpd/config.c
+++ b/smtpd/config.c
@@ -69,6 +69,8 @@ config_default(void)
 	conf->sc_scheduler_max_evp_batch_size = 256;
 	conf->sc_scheduler_max_msg_batch_size = 1024;
 
+        conf->sc_queue_path = PATH_SPOOL;
+
 	conf->sc_session_max_rcpt = 1000;
 	conf->sc_session_max_mails = 100;
 

--- a/smtpd/config.c
+++ b/smtpd/config.c
@@ -60,6 +60,7 @@ config_default(void)
 	(void)strlcpy(conf->sc_hostname, hostname, sizeof(conf->sc_hostname));
 
         conf->sc_sock_path = SMTPD_SOCKET;
+        conf->sc_path_chroot = PATH_CHROOT;
 	conf->sc_maxsize = DEFAULT_MAX_BODY_SIZE;
 	conf->sc_subaddressing_delim = SUBADDRESSING_DELIMITER;
 	conf->sc_ttl = SMTPD_QUEUE_EXPIRY;

--- a/smtpd/config.c
+++ b/smtpd/config.c
@@ -72,6 +72,8 @@ config_default(void)
 	conf->sc_scheduler_max_msg_batch_size = 1024;
 
         conf->sc_queue_path = PATH_SPOOL;
+        conf->sc_queue_user = SMTPD_QUEUE_USER;
+        conf->sc_queue_group = SMTPD_QUEUE_GROUP;
 
 	conf->sc_session_max_rcpt = 1000;
 	conf->sc_session_max_mails = 100;

--- a/smtpd/control.c
+++ b/smtpd/control.c
@@ -221,7 +221,7 @@ control(void)
 	stat_backend = env->sc_stat;
 	stat_backend->init();
 
-	if (chroot(PATH_CHROOT) == -1)
+	if (chroot(env->sc_path_chroot) == -1)
 		fatal("control: chroot");
 	if (chdir("/") == -1)
 		fatal("control: chdir(\"/\")");

--- a/smtpd/control.c
+++ b/smtpd/control.c
@@ -178,14 +178,14 @@ control_create_socket(void)
 
 	memset(&s_un, 0, sizeof(s_un));
 	s_un.sun_family = AF_UNIX;
-	if (strlcpy(s_un.sun_path, SMTPD_SOCKET,
+	if (strlcpy(s_un.sun_path, env->sc_sock_path,
 	    sizeof(s_un.sun_path)) >= sizeof(s_un.sun_path))
 		fatal("control: socket name too long");
 
 	if (connect(fd, (struct sockaddr *)&s_un, sizeof(s_un)) == 0)
 		fatalx("control socket already listening");
 
-	if (unlink(SMTPD_SOCKET) == -1)
+	if (unlink(env->sc_sock_path) == -1)
 		if (errno != ENOENT)
 			fatal("control: cannot unlink socket");
 
@@ -196,9 +196,9 @@ control_create_socket(void)
 	}
 	(void)umask(old_umask);
 
-	if (chmod(SMTPD_SOCKET,
+	if (chmod(env->sc_sock_path,
 		S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH) == -1) {
-		(void)unlink(SMTPD_SOCKET);
+		(void)unlink(env->sc_sock_path);
 		fatal("control: chmod");
 	}
 

--- a/smtpd/control.c
+++ b/smtpd/control.c
@@ -215,8 +215,8 @@ control(void)
 
 	purge_config(PURGE_EVERYTHING);
 
-	if ((pw = getpwnam(SMTPD_USER)) == NULL)
-		fatalx("unknown user " SMTPD_USER);
+	if ((pw = getpwnam(env->sc_smtpd_user)) == NULL)
+		fatalx("unknown user %s", env->sc_smtpd_user);
 
 	stat_backend = env->sc_stat;
 	stat_backend->init();

--- a/smtpd/lka.c
+++ b/smtpd/lka.c
@@ -430,8 +430,8 @@ lka(void)
 
 	purge_config(PURGE_LISTENERS);
 
-	if ((pw = getpwnam(SMTPD_USER)) == NULL)
-		fatalx("unknown user " SMTPD_USER);
+	if ((pw = getpwnam(env->sc_smtpd_user)) == NULL)
+		fatalx("unknown user %s", env->sc_smtpd_user);
 
 	config_process(PROC_LKA);
 

--- a/smtpd/lka_session.c
+++ b/smtpd/lka_session.c
@@ -507,14 +507,14 @@ lka_submit(struct lka_session *lks, struct rule *rule, struct expandnode *xn)
 			(void)strlcpy(ep->mda_user, xn->u.user, sizeof(ep->mda_user));
 		else {
 			user = !xn->parent->realuser ?
-			    SMTPD_USER :
+			    env->sc_smtpd_user :
 			    xn->parent->u.user;
 			(void)strlcpy(ep->mda_user, user, sizeof (ep->mda_user));
 
 			/* this battle needs to be fought ... */
-			if (strcmp(ep->mda_user, SMTPD_USER) == 0)
+			if (strcmp(ep->mda_user, env->sc_smtpd_user) == 0)
 				log_warn("commands executed from aliases "
-				    "run with %s privileges", SMTPD_USER);
+				    "run with %s privileges", env->sc_smtpd_user);
 
 			if (xn->type == EXPAND_FILENAME)
 				format = PATH_LIBEXEC"/mail.mboxfile -f %%{mbox.from} %s";

--- a/smtpd/parse.y
+++ b/smtpd/parse.y
@@ -191,7 +191,7 @@ typedef struct {
 %token	MAIL_FROM MAILDIR MASK_SRC MASQUERADE MATCH MAX_MESSAGE_SIZE MAX_DEFERRED MBOX MDA MTA MX
 %token	NO_DSN NO_VERIFY
 %token	ON
-%token	PKI PORT
+%token	PATH PKI PORT
 %token	QUEUE
 %token	RCPT_TO RECIPIENT RECEIVEDAUTH RELAY REJECT
 %token	SCHEDULER SENDER SENDERS SMTP SMTPS SOCKET SRC SUB_ADDR_DELIM
@@ -1651,6 +1651,7 @@ lookup(char *s)
 		{ "no-dsn",		NO_DSN },
 		{ "no-verify",		NO_VERIFY },
 		{ "on",			ON },
+		{ "path",		PATH },
 		{ "pki",		PKI },
 		{ "port",		PORT },
 		{ "queue",		QUEUE },

--- a/smtpd/parse.y
+++ b/smtpd/parse.y
@@ -1219,6 +1219,9 @@ opt_sock_listen : FILTER STRING {
 				YYERROR;
 			}
 		}
+		| PATH STRING {
+			conf->sc_sock_path = $2;
+		}
 		;
 
 opt_if_listen : INET4 {

--- a/smtpd/parse.y
+++ b/smtpd/parse.y
@@ -215,6 +215,7 @@ grammar		: /* empty */
 		| grammar ca '\n'
 		| grammar mda '\n'
 		| grammar mta '\n'
+		| grammar path '\n'
 		| grammar pki '\n'
 		| grammar queue '\n'
 		| grammar scheduler '\n'
@@ -378,6 +379,13 @@ MTA MAX_DEFERRED NUMBER  {
 | MTA LIMIT {
 	limits = dict_get(conf->sc_limits_dict, "default");
 } limits_mta
+;
+
+
+path:
+PATH CHROOT STRING {
+        conf->sc_path_chroot = $3;
+}
 ;
 
 

--- a/smtpd/parse.y
+++ b/smtpd/parse.y
@@ -459,6 +459,9 @@ QUEUE COMPRESSION {
 	}
 	free($3);
 }
+| QUEUE PATH STRING {
+        conf->sc_queue_path = $3;
+}
 ;
 
 

--- a/smtpd/parse.y
+++ b/smtpd/parse.y
@@ -183,6 +183,7 @@ typedef struct {
 %token	DHE DOMAIN
 %token	ENCRYPTION ERROR EXPAND_ONLY
 %token	FILTER FOR FORWARD_ONLY FROM
+%token	GROUP
 %token	HELO HELO_SRC HOST HOSTNAME HOSTNAMES
 %token	INCLUDE INET4 INET6
 %token	JUNK
@@ -1638,6 +1639,7 @@ lookup(char *s)
 		{ "for",		FOR },
 		{ "forward-only",      	FORWARD_ONLY },
 		{ "from",		FROM },
+		{ "group",		GROUP },
 		{ "helo",		HELO },
 		{ "helo-src",       	HELO_SRC },
 		{ "host",		HOST },

--- a/smtpd/parse.y
+++ b/smtpd/parse.y
@@ -471,6 +471,12 @@ QUEUE COMPRESSION {
 | QUEUE PATH STRING {
         conf->sc_queue_path = $3;
 }
+| QUEUE USER STRING {
+        conf->sc_queue_user = $3;
+}
+| QUEUE GROUP STRING {
+        conf->sc_queue_group = $3;
+}
 ;
 
 

--- a/smtpd/parse.y
+++ b/smtpd/parse.y
@@ -179,7 +179,7 @@ typedef struct {
 
 %token	ACTION ALIAS ANY ARROW AUTH AUTH_OPTIONAL
 %token	BACKUP BOUNCE
-%token	CA CERT CIPHERS COMPRESSION
+%token	CA CERT CHROOT CIPHERS COMPRESSION
 %token	DHE DOMAIN
 %token	ENCRYPTION ERROR EXPAND_ONLY
 %token	FILTER FOR FORWARD_ONLY FROM
@@ -1619,6 +1619,7 @@ lookup(char *s)
 		{ "bounce",		BOUNCE },
 		{ "ca",			CA },
 		{ "cert",		CERT },
+		{ "chroot",		CHROOT },
 		{ "ciphers",		CIPHERS },
 		{ "compression",	COMPRESSION },
 		{ "dhe",		DHE },

--- a/smtpd/parse.y
+++ b/smtpd/parse.y
@@ -506,6 +506,9 @@ SMTP LIMIT limits_smtp
 	}
 	conf->sc_subaddressing_delim = $3;
 }
+| SMTP USER STRING {
+	conf->sc_smtpd_user = $3;
+}
 ;
 
 

--- a/smtpd/pony.c
+++ b/smtpd/pony.c
@@ -164,7 +164,7 @@ pony(void)
 	if ((pw = getpwnam(SMTPD_USER)) == NULL)
 		fatalx("unknown user " SMTPD_USER);
 
-	if (chroot(PATH_CHROOT) == -1)
+	if (chroot(env->sc_path_chroot) == -1)
 		fatal("pony: chroot");
 	if (chdir("/") == -1)
 		fatal("pony: chdir(\"/\")");

--- a/smtpd/pony.c
+++ b/smtpd/pony.c
@@ -161,8 +161,8 @@ pony(void)
 	 */
 	purge_config(PURGE_TABLES|PURGE_RULES);
 
-	if ((pw = getpwnam(SMTPD_USER)) == NULL)
-		fatalx("unknown user " SMTPD_USER);
+	if ((pw = getpwnam(env->sc_smtpd_user)) == NULL)
+		fatalx("unknown user %s", env->sc_smtpd_user);
 
 	if (chroot(env->sc_path_chroot) == -1)
 		fatal("pony: chroot");

--- a/smtpd/queue.c
+++ b/smtpd/queue.c
@@ -637,7 +637,7 @@ queue(void)
 	env->sc_queue_flags |= QUEUE_EVPCACHE;
 	env->sc_queue_evpcache_size = 1024;
 
-	if (chroot(PATH_SPOOL) == -1)
+	if (chroot(env->sc_queue_path) == -1)
 		fatal("queue: chroot");
 	if (chdir("/") == -1)
 		fatal("queue: chdir(\"/\")");

--- a/smtpd/queue.c
+++ b/smtpd/queue.c
@@ -630,7 +630,7 @@ queue(void)
 
 	purge_config(PURGE_EVERYTHING & ~PURGE_DISPATCHERS);
 
-	if ((pw = getpwnam(SMTPD_QUEUE_USER)) == NULL)
+	if ((pw = getpwnam(env->sc_queue_user)) == NULL)
 		if ((pw = getpwnam(SMTPD_USER)) == NULL)
 			fatalx("unknown user " SMTPD_USER);
 

--- a/smtpd/queue.c
+++ b/smtpd/queue.c
@@ -631,8 +631,8 @@ queue(void)
 	purge_config(PURGE_EVERYTHING & ~PURGE_DISPATCHERS);
 
 	if ((pw = getpwnam(env->sc_queue_user)) == NULL)
-		if ((pw = getpwnam(SMTPD_USER)) == NULL)
-			fatalx("unknown user " SMTPD_USER);
+		if ((pw = getpwnam(env->sc_smtpd_user)) == NULL)
+			fatalx("unknown user %s", env->sc_smtpd_user);
 
 	env->sc_queue_flags |= QUEUE_EVPCACHE;
 	env->sc_queue_evpcache_size = 1024;

--- a/smtpd/queue_backend.c
+++ b/smtpd/queue_backend.c
@@ -141,16 +141,22 @@ queue_init(const char *name, int server)
 		backend = &queue_backend_proc;
 
 	if (server) {
-		if (ckdir(PATH_SPOOL, 0711, 0, 0, 1) == 0)
+                char offline[PATH_MAX];
+                char purge[PATH_MAX];
+                char temporary[PATH_MAX];
+                (void)snprintf(offline,   sizeof offline,   "%s%s", env->sc_queue_path, PATH_OFFLINE);
+                (void)snprintf(purge,     sizeof purge,     "%s%s", env->sc_queue_path, PATH_PURGE);
+                (void)snprintf(temporary, sizeof temporary, "%s%s", env->sc_queue_path, PATH_TEMPORARY);
+		if (ckdir(env->sc_queue_path, 0711, 0, 0, 1) == 0)
 			errx(1, "error in spool directory setup");
-		if (ckdir(PATH_SPOOL PATH_OFFLINE, 0770, 0, gr->gr_gid, 1) == 0)
+		if (ckdir(offline, 0770, 0, gr->gr_gid, 1) == 0)
 			errx(1, "error in offline directory setup");
-		if (ckdir(PATH_SPOOL PATH_PURGE, 0700, pwq->pw_uid, 0, 1) == 0)
+		if (ckdir(purge, 0700, pwq->pw_uid, 0, 1) == 0)
 			errx(1, "error in purge directory setup");
 
-		mvpurge(PATH_SPOOL PATH_TEMPORARY, PATH_SPOOL PATH_PURGE);
+		mvpurge(temporary, purge);
 
-		if (ckdir(PATH_SPOOL PATH_TEMPORARY, 0700, pwq->pw_uid, 0, 1) == 0)
+		if (ckdir(temporary, 0700, pwq->pw_uid, 0, 1) == 0)
 			errx(1, "error in purge directory setup");
 	}
 

--- a/smtpd/queue_backend.c
+++ b/smtpd/queue_backend.c
@@ -120,13 +120,13 @@ queue_init(const char *name, int server)
 	struct group	*gr;
 	int		 r;
 
-	pwq = getpwnam(SMTPD_QUEUE_USER);
+	pwq = getpwnam(env->sc_queue_user);
 	if (pwq == NULL)
-		errx(1, "unknown user %s", SMTPD_QUEUE_USER);
+		errx(1, "unknown user %s", env->sc_queue_user);
 
-	gr = getgrnam(SMTPD_QUEUE_GROUP);
+	gr = getgrnam(env->sc_queue_group);
 	if (gr == NULL)
-		errx(1, "unknown group %s", SMTPD_QUEUE_GROUP);
+		errx(1, "unknown group %s", env->sc_queue_group);
 
 	tree_init(&evpcache_tree);
 	TAILQ_INIT(&evpcache_list);

--- a/smtpd/queue_fs.c
+++ b/smtpd/queue_fs.c
@@ -659,16 +659,21 @@ queue_fs_init(struct passwd *pw, int server, const char *conf)
 	int		 ret;
 
 	/* remove incoming/ if it exists */
-	if (server)
-		mvpurge(PATH_SPOOL PATH_INCOMING, PATH_SPOOL PATH_PURGE);
+	if (server) {
+                char incoming[PATH_MAX];
+                char purge[PATH_MAX];
+                (void)snprintf(incoming, sizeof incoming, "%s%s", env->sc_queue_path, PATH_INCOMING);
+                (void)snprintf(purge,    sizeof purge,    "%s%s", env->sc_queue_path, PATH_PURGE);
+		mvpurge(incoming, purge);
+        }
 
 	fsqueue_envelope_path(0, path, sizeof(path));
 
 	ret = 1;
 	for (n = 0; n < nitems(paths); n++) {
-		(void)strlcpy(path, PATH_SPOOL, sizeof(path));
+		(void)strlcpy(path, env->sc_queue_path, sizeof(path));
 		if (strlcat(path, paths[n], sizeof(path)) >= sizeof(path))
-			errx(1, "path too long %s%s", PATH_SPOOL, paths[n]);
+			errx(1, "path too long %s%s", env->sc_queue_path, paths[n]);
 		if (ckdir(path, 0700, pw->pw_uid, 0, server) == 0)
 			ret = 0;
 	}

--- a/smtpd/scheduler.c
+++ b/smtpd/scheduler.c
@@ -438,8 +438,8 @@ scheduler(void)
 
 	purge_config(PURGE_EVERYTHING & ~PURGE_DISPATCHERS);
 
-	if ((pw = getpwnam(SMTPD_USER)) == NULL)
-		fatalx("unknown user " SMTPD_USER);
+	if ((pw = getpwnam(env->sc_smtpd_user)) == NULL)
+		fatalx("unknown user %s", env->sc_smtpd_user);
 
 	config_process(PROC_SCHEDULER);
 

--- a/smtpd/scheduler.c
+++ b/smtpd/scheduler.c
@@ -445,7 +445,7 @@ scheduler(void)
 
 	backend->init(backend_scheduler);
 
-	if (chroot(PATH_CHROOT) == -1)
+	if (chroot(env->sc_path_chroot) == -1)
 		fatal("scheduler: chroot");
 	if (chdir("/") == -1)
 		fatal("scheduler: chdir(\"/\")");

--- a/smtpd/smtp.c
+++ b/smtpd/smtp.c
@@ -132,8 +132,15 @@ smtp_setup_listeners(void)
 {
 	struct listener	       *l;
 	int			opt;
+	int next_inherited = 4;
 
 	TAILQ_FOREACH(l, env->sc_listeners, entry) {
+		/* Some fds may be already set up through inheritance. */
+		if (l->fd != -1) {
+			l->fd = next_inherited;
+			next_inherited++;
+			continue;
+		}
 		if ((l->fd = socket(l->ss.ss_family, SOCK_STREAM, 0)) == -1) {
 			if (errno == EAFNOSUPPORT) {
 				log_warn("smtpd: socket");

--- a/smtpd/smtpctl.c
+++ b/smtpd/smtpctl.c
@@ -139,7 +139,7 @@ srv_connect(void)
 
 	memset(&s_un, 0, sizeof(s_un));
 	s_un.sun_family = AF_UNIX;
-	(void)strlcpy(s_un.sun_path, SMTPD_SOCKET, sizeof(s_un.sun_path));
+	(void)strlcpy(s_un.sun_path, env->sc_sock_path, sizeof(s_un.sun_path));
 	if (connect(ctl_sock, (struct sockaddr *)&s_un, sizeof(s_un)) == -1) {
 		saved_errno = errno;
 		close(ctl_sock);

--- a/smtpd/smtpctl.c
+++ b/smtpd/smtpctl.c
@@ -1045,6 +1045,16 @@ do_spf_walk(int argc, struct parameter *argv)
 	return spfwalk(argc, argv);
 }
 
+void
+load_config(void)
+{
+	char *conffile = CONF_FILE;
+	if ((env = config_default()) == NULL)
+		err(1, NULL);
+	if (parse_config(env, conffile, 0))
+		exit(1);
+}
+
 #define cmd_install_priv(s, f) \
 	cmd_install((s), privileged ? (f) : do_permission_denied)
 
@@ -1056,6 +1066,8 @@ main(int argc, char **argv)
 	char		*argv_mailq[] = { "show", "queue", NULL };
 
 	__progname = ssh_get_progname(argv[0]);
+
+        load_config();
 
 	sendmail_compat(argc, argv);
 	privileged = geteuid() == 0;

--- a/smtpd/smtpctl.c
+++ b/smtpd/smtpctl.c
@@ -166,7 +166,7 @@ offline_file(void)
 	int	fd;
 	FILE   *fp;
 
-	if (!bsnprintf(path, sizeof(path), "%s%s/%lld.XXXXXXXXXX", PATH_SPOOL,
+	if (!bsnprintf(path, sizeof(path), "%s%s/%lld.XXXXXXXXXX", env->sc_queue_path,
 		PATH_OFFLINE, (long long int) time(NULL)))
 		err(EX_UNAVAILABLE, "snprintf");
 
@@ -715,7 +715,7 @@ do_show_envelope(int argc, struct parameter *argv)
 	char	 buf[PATH_MAX];
 
 	if (!bsnprintf(buf, sizeof(buf), "%s%s/%02x/%08x/%016" PRIx64,
-	    PATH_SPOOL,
+	    env->sc_queue_path,
 	    PATH_QUEUE,
 	    (evpid_to_msgid(argv[0].u.u_evpid) & 0xff000000) >> 24,
 	    evpid_to_msgid(argv[0].u.u_evpid),
@@ -747,7 +747,7 @@ do_show_message(int argc, struct parameter *argv)
 		msgid = argv[0].u.u_msgid;
 
 	if (!bsnprintf(buf, sizeof(buf), "%s%s/%02x/%08x/message",
-		PATH_SPOOL,
+		env->sc_queue_path,
 		PATH_QUEUE,
 		(msgid & 0xff000000) >> 24,
 		msgid))
@@ -774,11 +774,11 @@ do_show_queue(int argc, struct parameter *argv)
 	if (!srv_connect()) {
 		log_init(1, LOG_MAIL);
 		queue_init("fs", 0);
-		if (chroot(PATH_SPOOL) == -1 || chdir("/") == -1)
-			err(1, "%s", PATH_SPOOL);
+		if (chroot(env->sc_queue_path) == -1 || chdir("/") == -1)
+			err(1, "%s", env->sc_queue_path);
 		fts = fts_open(qpath, FTS_PHYSICAL|FTS_NOCHDIR, NULL);
 		if (fts == NULL)
-			err(1, "%s/queue", PATH_SPOOL);
+			err(1, "%s/queue", env->sc_queue_path);
 
 		while ((ftse = fts_read(fts)) != NULL) {
 			switch (ftse->fts_info) {

--- a/smtpd/smtpctl.c
+++ b/smtpd/smtpctl.c
@@ -509,8 +509,8 @@ droppriv(void)
 	if (geteuid())
 		return;
 
-	if ((pw = getpwnam(SMTPD_USER)) == NULL)
-		errx(1, "unknown user " SMTPD_USER);
+	if ((pw = getpwnam(env->sc_smtpd_user)) == NULL)
+		errx(1, "unknown user %s", env->sc_smtpd_user);
 
 	if ((setgroups(1, &pw->pw_gid) ||
 	    setresgid(pw->pw_gid, pw->pw_gid, pw->pw_gid) ||

--- a/smtpd/smtpctl.c
+++ b/smtpd/smtpctl.c
@@ -1048,7 +1048,10 @@ do_spf_walk(int argc, struct parameter *argv)
 void
 load_config(void)
 {
-	char *conffile = CONF_FILE;
+	char *conffile;
+	conffile = getenv("SMTPD_CONFIG_FILE");
+	if (!conffile)
+		conffile = CONF_FILE;
 	if ((env = config_default()) == NULL)
 		err(1, NULL);
 	if (parse_config(env, conffile, 0))

--- a/smtpd/smtpd.c
+++ b/smtpd/smtpd.c
@@ -315,7 +315,7 @@ parent_shutdown(void)
 		pid = waitpid(WAIT_MYPGRP, NULL, 0);
 	} while (pid != -1 || (pid == -1 && errno == EINTR));
 
-	unlink(SMTPD_SOCKET);
+	unlink(env->sc_sock_path);
 
 	log_info("Exiting");
 	exit(0);

--- a/smtpd/smtpd.c
+++ b/smtpd/smtpd.c
@@ -1126,9 +1126,6 @@ smtpd(void) {
 	offline_timeout.tv_usec = 0;
 	evtimer_add(&offline_ev, &offline_timeout);
 
-	if (pidfile(NULL) < 0)
-		err(1, "pidfile");
-
 	purge_task();
 
 	if (pledge("stdio rpath wpath cpath fattr flock tmppath "

--- a/smtpd/smtpd.c
+++ b/smtpd/smtpd.c
@@ -1266,8 +1266,8 @@ purge_task(void)
 			log_warn("warn: purge_task: fork");
 			break;
 		case 0:
-			if ((pw = getpwnam(SMTPD_QUEUE_USER)) == NULL)
-				fatalx("unknown user " SMTPD_QUEUE_USER);
+			if ((pw = getpwnam(env->sc_queue_user)) == NULL)
+				fatalx("unknown user %s", env->sc_queue_user);
 			if (chroot(purge) == -1)
 				fatal("smtpd: chroot");
 			if (chdir("/") == -1)

--- a/smtpd/smtpd.c
+++ b/smtpd/smtpd.c
@@ -1249,9 +1249,11 @@ purge_task(void)
 	int		 n;
 	uid_t		 uid;
 	gid_t		 gid;
+        char purge[PATH_MAX];
+        (void)snprintf(purge, sizeof purge, "%s%s", env->sc_queue_path, PATH_PURGE);
 
 	n = 0;
-	if ((d = opendir(PATH_SPOOL PATH_PURGE))) {
+	if ((d = opendir(purge))) {
 		while (readdir(d) != NULL)
 			n++;
 		closedir(d);
@@ -1266,7 +1268,7 @@ purge_task(void)
 		case 0:
 			if ((pw = getpwnam(SMTPD_QUEUE_USER)) == NULL)
 				fatalx("unknown user " SMTPD_QUEUE_USER);
-			if (chroot(PATH_SPOOL PATH_PURGE) == -1)
+			if (chroot(purge) == -1)
 				fatal("smtpd: chroot");
 			if (chdir("/") == -1)
 				fatal("smtpd: chdir");
@@ -1436,8 +1438,10 @@ offline_scan(int fd, short ev, void *arg)
 	FTS		*fts = arg;
 	FTSENT		*e;
 	int		 n = 0;
+        char offline[PATH_MAX];
+        (void)snprintf(offline, sizeof offline, "%s%s", env->sc_queue_path, PATH_OFFLINE);
 
-	path_argv[0] = PATH_SPOOL PATH_OFFLINE;
+	path_argv[0] = offline;
 	path_argv[1] = NULL;
 
 	if (fts == NULL) {
@@ -1496,7 +1500,7 @@ offline_enqueue(char *name)
 	struct passwd	*pw;
 	int		 pathlen;
 
-	pathlen = asprintf(&path, "%s/%s", PATH_SPOOL PATH_OFFLINE, name);
+	pathlen = asprintf(&path, "%s%s/%s", env->sc_queue_path, PATH_OFFLINE, name);
 	if (pathlen == -1) {
 		log_warnx("warn: smtpd: asprintf");
 		return (-1);

--- a/smtpd/smtpd.h
+++ b/smtpd/smtpd.h
@@ -518,6 +518,7 @@ struct listener {
 struct smtpd {
 	char				sc_conffile[PATH_MAX];
 	char                           *sc_sock_path;
+	char                           *sc_path_chroot;
 	size_t				sc_maxsize;
 
 #define SMTPD_OPT_VERBOSE		0x00000001

--- a/smtpd/smtpd.h
+++ b/smtpd/smtpd.h
@@ -517,6 +517,7 @@ struct listener {
 
 struct smtpd {
 	char				sc_conffile[PATH_MAX];
+	char                           *sc_sock_path;
 	size_t				sc_maxsize;
 
 #define SMTPD_OPT_VERBOSE		0x00000001

--- a/smtpd/smtpd.h
+++ b/smtpd/smtpd.h
@@ -539,6 +539,7 @@ struct smtpd {
 	uint32_t			sc_queue_flags;
 	char			       *sc_queue_key;
 	size_t				sc_queue_evpcache_size;
+	char			       *sc_queue_path;
 
 	size_t				sc_session_max_rcpt;
 	size_t				sc_session_max_mails;

--- a/smtpd/smtpd.h
+++ b/smtpd/smtpd.h
@@ -519,6 +519,7 @@ struct smtpd {
 	char				sc_conffile[PATH_MAX];
 	char                           *sc_sock_path;
 	char                           *sc_path_chroot;
+	char                           *sc_smtpd_user;
 	size_t				sc_maxsize;
 
 #define SMTPD_OPT_VERBOSE		0x00000001

--- a/smtpd/smtpd.h
+++ b/smtpd/smtpd.h
@@ -542,6 +542,8 @@ struct smtpd {
 	char			       *sc_queue_key;
 	size_t				sc_queue_evpcache_size;
 	char			       *sc_queue_path;
+	char			       *sc_queue_user;
+	char			       *sc_queue_group;
 
 	size_t				sc_session_max_rcpt;
 	size_t				sc_session_max_mails;


### PR DESCRIPTION
This patchset allows running many parts of OpenSMTPD with a non-standard configuration.

See the commit messages for more information on each commit.

This is enough to run OpenSMTPD as an unprivileged user without any system-wide configuration, along with a few other hacks: https://github.com/catern/OpenSMTPD/pull/1