### PR TITLE
Fix `match from socket`

### DIFF
--- a/smtpd/ruleset.c
+++ b/smtpd/ruleset.c
@@ -69,7 +69,7 @@ ruleset_match_from(struct rule *r, const struct envelope *evp)
 
 	if (r->flag_from_socket) {
 		/* XXX - socket needs to be distinguished from "local" */
-		return -1;
+		return 0;
 	}
 
 	if (evp->flags & EF_INTERNAL)


### PR DESCRIPTION
With the following configuration file, `sendmail` fails with 451 Temporary Failure:
```
listen on lo hostname [censored]

action do_relay relay host smtp://[censored] helo [censored]

match from socket for any action do_relay
match from local for any action do_relay
```

On the other hand, with the following, it succeeds:
```

listen on lo hostname [censored]

action do_relay relay host smtp://[censored] helo [censored]

match from local for any action do_relay
```

My assumption is this is due to this `return -1;`, supposed to imply a temporary failure that stops processing of further rules, that should be a `return 0;`, no match.

I have on the other hand not seriously tested this change, as I'd like to have a first opinion on whether that's likely to be a good idea or not.

I also wonder whether this should be backported -- would hope that it is, but am not sure about it.