### PR TITLE
dockerfile minor style changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,43 @@
-FROM alpine:3.9 as build
+FROM alpine:3.10 as build
 
 WORKDIR /opensmtpd
 
-# libressl is used for testing only
 RUN apk add --no-cache \
-    ca-certificates \
-    automake \
     autoconf \
-    libtool \
-    gcc \
-    make \
-    musl-dev \
+    automake \
     bison \
+    ca-certificates \
+    fts-dev \
+    gcc \
+    libasr-dev \
     libevent-dev \
     libtool \
-    libasr-dev \
-    fts-dev \
-    zlib-dev \
+    libtool \
+    make \
+    musl-dev \
+    openssl \
     openssl-dev \
-    openssl
+    zlib-dev
 
-#For testing
-RUN mkdir -p /var/lib/opensmtpd/empty/ && \
-    adduser _smtpd -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false && \
-    adduser _smtpq -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false && \
-    mkdir -p /var/spool/smtpd && \
-    chmod 711 /var/spool/smtpd
+# For testing
+RUN mkdir -p /var/lib/opensmtpd/empty \
+  && adduser _smtpd -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false \
+  && adduser _smtpq -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false \
+  && mkdir -p /var/spool/smtpd \
+  && chmod 711 /var/spool/smtpd
 
 COPY . /opensmtpd
 
-#build opensmtpd
-RUN rm -r /usr/local/
-RUN ./bootstrap && \
-    ./configure --with-gnu-ld --sysconfdir=/etc/mail --with-path-empty=/var/lib/opensmtpd/empty/ && \
-    make && \
-    make install
+# build opensmtpd
+RUN rm -r /usr/local/ \
+  && ./bootstrap \
+  && ./configure --with-gnu-ld \
+       --sysconfdir=/etc/mail \
+       --with-path-empty=/var/lib/opensmtpd/empty \
+  && make \
+  && make install
 
-FROM alpine:3.9
+FROM alpine:3.10
 LABEL maintainer="Arthur Moore <Arthur.Moore.git@cd-net.net>"
 
 EXPOSE 25
@@ -50,17 +51,23 @@ WORKDIR /var/spool/smtpd
 ENTRYPOINT ["smtpd", "-d"]
 CMD ["-P", "mda"]
 
-RUN apk add --no-cache openssl libevent libasr fts zlib ca-certificates && \
-    mkdir -p /var/lib/opensmtpd/empty/ && \
-    adduser _smtpd -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false && \
-    adduser _smtpq -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false && \
-    mkdir -p /etc/mail/ && \
-    mkdir -p /var/spool/smtpd && \
-    chmod 711 /var/spool/smtpd
+RUN apk add --no-cache \
+      ca-certificates \
+      fts \
+      libasr \
+      libevent \
+      openssl \
+      zlib \
+  && mkdir -p /var/lib/opensmtpd/empty \
+  && adduser _smtpd -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false \
+  && adduser _smtpq -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false \
+  && mkdir -p /etc/mail \
+  && mkdir -p /var/spool/smtpd \
+  && chmod 711 /var/spool/smtpd
 
 COPY --from=build /usr/local/ /usr/local/
 
 COPY smtpd/smtpd.conf /etc/mail
 
-#OpenSMTPD needs root permissions to open port 25.
-#It immediately changes to running as _smtpd after that.
+# OpenSMTPD needs root permissions to open port 25.
+# It immediately changes to running as _smtpd after that.


### PR DESCRIPTION
Alpine Linux updated to 3.10

Rest is style changes:
- package lists sorted
- `&&` are in the beginning of the line (bestpractice, readability)
- removed unnecessary trailing `/` for `mkdir`
- split long lines into smaller ones