### PR TITLE
[RFC] prepare folders for configs and dockerfiles

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,24 @@
+# Dockerfiles
+
+## Disclaimer
+
+This folder contains dockerfiles that can be used for developing and OpenSMTPD.
+These dockerfiles are intended to be used for dev/test cycle and ARE NOT
+intended to be a delivery mechanism for end users and should not be published
+on external resouces like DockerHub.  Dockerfiles in this folder can be used as
+a reference for package maintainers of various distributions.
+
+
+## Usage
+
+For each distribution there is a separate dockerfile with a distro name
+suffixed.  E.g. `Dockerfile.alpine` is a dockerfile that builds OpenSMTPD in
+Alpine Linux environment
+
+To build:
+
+`docker build -f docker/Dockerfile.alpine -t opensmtpd-alpine`
+
+
+
+...to be continued..

--- a/etc/README.md
+++ b/etc/README.md
@@ -1,0 +1,3 @@
+This directory will contain example OpenSMTPD config  files that can be used as
+a reference or for testing specific usecases. Tests that are run as part of
+CI/CD process in docker containers will utilize these files.


### PR DESCRIPTION
@poolpOrg this is how I envisioned a new folder structure.

As discussed in https://github.com/OpenSMTPD/OpenSMTPD/issues/947
We can put configs in `etc/` and dockerfiles and maybe some related scripts in `docker/` to avoid polluting the root of the repo