### PR TITLE
docker: add explicit flags to use libressl on archlinux

### DIFF
--- a/docker/Dockerfile.archlinux
+++ b/docker/Dockerfile.archlinux
@@ -38,6 +38,8 @@ COPY . /opensmtpd
 RUN ./bootstrap \
   && ./configure --with-gnu-ld \
        --sysconfdir=/etc/mail \
+       --with-cflags='-I/usr/include/libressl -L/usr/lib/libressl -Wl,-rpath=/usr/lib/libressl' \
        --with-path-empty=/var/lib/opensmtpd/empty \
+       --with-auth-pam \
   && make \
   && make install


### PR DESCRIPTION
Reproduces https://github.com/OpenSMTPD/OpenSMTPD/issues/958