### PR TITLE
[RFC] fix: arc4random_stir header with libressl

### DIFF
--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -127,7 +127,7 @@ unsigned int arc4random(void);
 void arc4random_stir(void);
 #elif defined(HAVE_ARC4RANDOM) || defined(LIBRESSL_VERSION_NUMBER)
 /* Recent system/libressl implementation; no need for explicit stir */
-# define arc4random_stir()
+void arc4random_stir(void);
 #else
 /* openbsd-compat/arc4random.c provides arc4random_stir() */
 void arc4random_stir(void);


### PR DESCRIPTION
fixes #958 and #944

This is a very **LOW CONFIDENCE** solution as I don't really understand what I am doing

