### PR TITLE
ci: add archlinux docker build to docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,3 +1,11 @@
+# This workflow leverages GitHub's Actions docker capabilities to run builds
+# and tests on platforms not available directly.
+# We have multiple dimensions to test: 
+# - OS Distribution
+# - TLS library implementation: libress, openssl
+# - libc implementations: glibc, musl
+# - compiler: gcc, clang (not yet tested)
+
 on: [push]
 name: Docker builds
 jobs:
@@ -8,5 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Alpine Linux build
+    - name: Alpine Linux musl+openssl
       run: docker build . --file docker/Dockerfile.alpine --tag opensmtpd-alpine:$(date +%s)
+    - name: Archlinux glibc+libressl
+      run: docker build . --file docker/Dockerfile.archlinux --tag opensmtpd-archlinux:$(date +%s)

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,10 +1,14 @@
-name: Ubuntu build
+# Ubuntu build that leverages GitHub's native Actions environment
+# This build uses openssl + glibc 
+
+name: Ubuntu build (openssl+glibc)
 
 on: [push]
 
 jobs:
   build:
 
+    # Ubuntu latest is really latest LTS
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
This exposes #944 #958  to our Actions CI.

Archlinux + libressl build is failing