### PR TITLE
ci: clang scan script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ cov-analysis-linux64/
 cov-analysis-linux64.tgz
 opensmtpd.tgz
 
+# Clang scan-build
+clang-report/
+
 
 # TLS certs
 open.smtpd.cert

--- a/ci/scripts/clang_scan.sh
+++ b/ci/scripts/clang_scan.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -eu
+
+# Unconditionally go to the root level of the git repo.
+# If you invoke it from outside of the repo go to
+# the script location first
+cd "$(dirname "$0")"
+cd "$(git rev-parse --show-toplevel)"
+
+# Clang Scan script
+# 
+# USAGE: 
+# - clang must be installed
+# - make sure you have clean repository, 
+#   e.g. git clean -ffdx
+# - if you want to download github badge set CLANG_SCAN_BADGE_REQUIRED variable
+# - Run script from anywhere inside the repository
+#   ./ci/scripts/clang_scan.sh
+#   or 
+#   CLANG_SCAN_BADGE_REQUIRED=1 ./ci/scripts/clang_scan.sh
+# 
+
+if ! type scan-build > /dev/null; then
+  echo "clang scan-build is missing"
+  exit 1
+fi
+
+# Unconditionally go to the root level of the git repo.
+# If you invoke it from outside of the repo go to
+# the script location first
+cd "$(dirname "$0")"
+# This moves us to the root of the repo
+cd "$(git rev-parse --show-toplevel)"
+
+# Get short SHA of the HEAD
+sha=$(git rev-parse --short HEAD)
+
+results_dir=${CLANG_SCAN_RESULTS_DIR:-clang-report}
+mkdir -p "$results_dir"
+ 
+# Build with scan-build
+./bootstrap
+./configure
+scan-build -o "$results_dir" \
+    --keep-empty \
+    --html-title="OpenSMTPD $sha" make
+
+
+set -x
+# conditionally generate badge
+if [ -z "${CLANG_SCAN_BADGE_REQUIRED:-}" ]; then
+  echo "Skipping badge generation"
+else
+  echo "Generating badge"
+  . ci/scripts/imports/badge.sh
+  cd "$results_dir"
+  cd "$( find  . -type d | sort | tail -n1 )"
+  issues_nr="$( find . -name "report-*" | wc -l)"
+  download_badge "$issues_nr" "clang analysis" "$(pwd)" 30
+fi

--- a/ci/scripts/generate_certs.sh
+++ b/ci/scripts/generate_certs.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Generate self-signed SSL certs
+# Usage: ./generate_certs.sh
+
 days=3560           # 10 years
 config="$(dirname "$0")/ssl.conf"
 cert="open.smtpd.cert"

--- a/ci/scripts/imports/badge.sh
+++ b/ci/scripts/imports/badge.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Copyright 2019 Neovim Project Contributors (https://neovim.io/)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Helper functions for getting badges.
+
+# Get code quality color.
+# ${1}:   Amount of bugs actually found.
+# ${2}:   Maximum number of bugs above which color will be red. Defaults to 20.
+# ${3}:   Maximum number of bugs above which color will be yellow. Defaults to
+#         $1 / 2.
+# Output: 24-bit hexadecimal representation of the color (xxxxxx).
+get_code_quality_color() {
+  bugs=$1 ; shift  # shift will fail if there is no argument
+  max_bugs=${1:-20}
+  yellow_threshold=${2:-$(( max_bugs / 2 ))}
+
+  red=255
+  green=255
+  blue=0
+
+  bugs=$(( bugs < max_bugs ? bugs : max_bugs))
+  if test $bugs -ge "$yellow_threshold" ; then
+    green=$(( 255 - 255 * (bugs - yellow_threshold) / yellow_threshold ))
+  else
+    red=$(( 255 * bugs / yellow_threshold ))
+  fi
+
+  printf "%02x%02x%02x" $red $green $blue
+}
+
+# Get code quality badge.
+# ${1}:   Amount of bugs actually found.
+# ${2}:   Badge text.
+# ${3}:   Directory where to save badge to.
+# ${3}:   Maximum number of bugs above which color will be red. Defaults to 20.
+# ${4}:   Maximum number of bugs above which color will be yellow. Defaults to
+#         $1 / 2.
+# Output: 24-bit hexadecimal representation of the color (xxxxxx).
+download_badge() {
+  bugs=$1 ; shift
+  badge_text="$1" ; shift
+  reports_dir="$1" ; shift
+  max_bugs=${1:-20}
+  yellow_threshold=${2:-$(( max_bugs / 2 ))}
+
+  code_quality_color="$(
+    get_code_quality_color $bugs $max_bugs $yellow_threshold)"
+  badge="${badge_text}-${bugs}-${code_quality_color}"
+
+  rm -f "$reports_dir/badge.svg"
+  
+  response="$(
+    curl --tlsv1 "https://img.shields.io/badge/${badge}.svg" \
+      -o"$reports_dir/badge.svg" 2>&1)"
+  
+  if ! grep -F 'xmlns="http://www.w3.org/2000/svg"' "$reports_dir/badge.svg"  ; then
+    echo "Failed to download badge to $reports_dir: $response"
+    rm -f "$reports_dir/badge.svg"
+  fi
+}


### PR DESCRIPTION
Script that generates clang `scan-build` report and optionally generates a badge for it.

It will be used in a actions workflow in website repo to publish daily report