### PR TITLE
Fix typos in smtpd.conf.5

### DIFF
--- a/smtpd/smtpd.conf.5
+++ b/smtpd/smtpd.conf.5
@@ -927,7 +927,7 @@ The following phases are currently supported:
 .El
 .Pp
 At each phase,
-multiple criterias may be checked:
+multiple criteria may be checked:
 .Bl -column XXXXXXXXXXXXXXXXXXXXX -offset indent
 .It fcrdns                        Ta forward-confirmed reverse DNS is valid
 .It rdns                          Ta session has a reverse DNS
@@ -938,11 +938,11 @@ multiple criterias may be checked:
 .It rcpt-to Pf < Ar table Ns >   Ta recipient address is in table
 .El
 .Pp
-All criterias from previous phases are available to subsequent phases,
+All criteria from previous phases are available to subsequent phases,
 so while the helo criteria is not available before the helo or ehlo phase,
 the fcrdns criteria is available in all phases.
 .Pp
-Criterias may all be negated by prefixing them with an exclamation mark:
+Criteria may all be negated by prefixing them with an exclamation mark:
 .Bl -column XXXXXXXXXXXXXXXXXXXXX -offset indent
 .It ! fcrdns                     Ta forward-confirmed reverse DNS is invalid
 .El


### PR DESCRIPTION
The word "criteria" is already the plural of "criterion".