### PR TITLE
Document that the local socket can also be filtered

### DIFF
--- a/smtpd/smtpd.conf.5
+++ b/smtpd/smtpd.conf.5
@@ -536,19 +536,26 @@ With the
 option, clients must also provide a valid certificate
 to establish an SMTP session.
 .El
-.It Ic listen on Cm socket Oo Ar mask-src Oc Op Cm tag Ar tag
+.It Ic listen on Cm socket Op Ar options
 Listen for incoming SMTP connections on the Unix domain socket
 .Pa /var/run/smtpd.sock .
 This is done by default, even if the directive is absent.
-If the
-.Cm mask-src
-option is specified, printing of the HELO name, hostname, and IP
-address of the originating host is suppressed in Received: header lines.
-If the
-.Cm tag
-option is specified,
-sessions initiated from the socket will be tagged
+.Pp
+The
+.Ar options
+are as follows:
+.Bl -tag -width Ds
+.It Ic filter Ar name
+Apply filter
+.Ar name
+on connections handled by this listener.
+.It Cm mask-src
+Omit the HELO name, hostname, and IP address of the originating host in
+Received: header lines.
+.It Cm tag Ar tag
+Sessions initiated from the socket will be tagged
 .Ar tag .
+.El
 .It Ic match Ar options Cm action Ar name
 If at least one mail envelope matches the
 .Ar options


### PR DESCRIPTION
This fact is useful to people whose MUA sends mail using the sendmail
command, and who want to pass this mail through filters.