### PR TITLE
ci: remove readme file that breaks srht builds

### DIFF
--- a/.builds/README.md
+++ b/.builds/README.md
@@ -1,3 +1,0 @@
-This directory contains build manifests for SourceHut
-
-https://man.sr.ht/tutorials/builds.sr.ht/github-integration.md


### PR DESCRIPTION
@ddevault confirms that only build manifests are expected in `.builds/` directory

> It looks like presence of other files in .builds/ directory (in my case - 
readme.md) breaks build/dispatch (not sure which one)
>
> You can see it here:
>
>https://github.com/OpenSMTPD/OpenSMTPD/pull/1004
>https://github.com/OpenSMTPD/OpenSMTPD/pull/1005
>
>The PR that removes readme file from the builds/ directory triggers sourcehut 
build. The other one - does not.

```
From:	Drew DeVault <sir@cmpwn.com>
To:	Me
CC:	gilles@poolp.org
Date:	11/25/19 5:28 AM

Aye, this is not supported. You need to leave only build manifests in
your builds directory.
```