### PR TITLE
smtpctl: check correct egid at startup

### DIFF
--- a/smtpd/smtpctl.c
+++ b/smtpd/smtpctl.c
@@ -1061,13 +1061,23 @@ do_spf_walk(int argc, struct parameter *argv)
 int
 main(int argc, char **argv)
 {
-	gid_t		 gid;
+	gid_t		 egid, gid;
+	struct group    *gr;
 	int		 privileged;
 	char		*argv_mailq[] = { "show", "queue", NULL };
 
 #ifndef HAVE___PROGNAME
 	__progname = ssh_get_progname(argv[0]);
 #endif
+
+	/* Sanity check that too many Linux distros fail */
+	egid = getegid();
+	gr = getgrnam(SMTPD_QUEUE_GROUP);
+	if (gr == NULL)
+		warnx("installation problem: unknown group %s", SMTPD_QUEUE_GROUP);
+	if (gr != NULL && gr->gr_gid != egid)
+		warnx("installation problem: this program must be setgid %s",
+		     SMTPD_QUEUE_GROUP);
 
 	sendmail_compat(argc, argv);
 	privileged = geteuid() == 0;

--- a/smtpd/smtpctl.c
+++ b/smtpd/smtpctl.c
@@ -1072,9 +1072,9 @@ main(int argc, char **argv)
 
 	/* check that smtpctl was installed setgid */
 	if ((gr = getgrnam(SMTPD_QUEUE_GROUP)) == NULL)
-		warnx("unknown group %s", SMTPD_QUEUE_GROUP);
+		errx(1, "unknown group %s", SMTPD_QUEUE_GROUP);
 	else if (gr->gr_gid != getegid())
-		warnx("this program must be setgid %s", SMTPD_QUEUE_GROUP);
+		errx(1, "this program must be setgid %s", SMTPD_QUEUE_GROUP);
 
 	sendmail_compat(argc, argv);
 	privileged = geteuid() == 0;

--- a/smtpd/smtpctl.c
+++ b/smtpd/smtpctl.c
@@ -1061,7 +1061,7 @@ do_spf_walk(int argc, struct parameter *argv)
 int
 main(int argc, char **argv)
 {
-	gid_t		 egid, gid;
+	gid_t		 gid;
 	struct group    *gr;
 	int		 privileged;
 	char		*argv_mailq[] = { "show", "queue", NULL };
@@ -1070,14 +1070,11 @@ main(int argc, char **argv)
 	__progname = ssh_get_progname(argv[0]);
 #endif
 
-	/* Sanity check that too many Linux distros fail */
-	egid = getegid();
-	gr = getgrnam(SMTPD_QUEUE_GROUP);
-	if (gr == NULL)
-		warnx("installation problem: unknown group %s", SMTPD_QUEUE_GROUP);
-	if (gr != NULL && gr->gr_gid != egid)
-		warnx("installation problem: this program must be setgid %s",
-		     SMTPD_QUEUE_GROUP);
+	/* check that smtpctl was installed setgid */
+	if ((gr = getgrnam(SMTPD_QUEUE_GROUP)) == NULL)
+		warnx("unknown group %s", SMTPD_QUEUE_GROUP);
+	else if (gr->gr_gid != getegid())
+		warnx("this program must be setgid %s", SMTPD_QUEUE_GROUP);
 
 	sendmail_compat(argc, argv);
 	privileged = geteuid() == 0;


### PR DESCRIPTION
Too many Linux distributions (Debian, Ubuntu, Arch, Fedora) got smtpctl
permissions wrong. The typical pattern (applies to Arch) is:

 * The build machine does not have the smtpq group
 * The build runs as non-root with --with-group-queue=smtpq
 * The smtpq group is created in post-install via systemd-sysusers
 * There is nothing that makes smtpctl setgid smtpq
 * The package even seems to work until offline delivery is attempted

Let's make sure users complain to the distributors if the above happens,
instead of having a silently broken installation.

See also the (invalid) ticket #1012.