### PR TITLE
openbsd-compat: fix out-of-tree builds

### DIFF
--- a/openbsd-compat/Makefile.am
+++ b/openbsd-compat/Makefile.am
@@ -191,7 +191,7 @@ EXTRA_DIST +=	sys/queue.h
 EXTRA_DIST +=	sys/tree.h
 EXTRA_DIST +=	bsd-vis.h
 
-AM_CPPFLAGS = -I$(top_srcdir)/smtpd -I$(top_srcdir)/openbsd-compat
+AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/smtpd -I$(top_srcdir)/openbsd-compat
 
 if !NEED_ERR_H
 AM_CPPFLAGS += -I$(top_srcdir)/openbsd-compat/err_h


### PR DESCRIPTION
In out-of-tree builds anything inside openbsd-compat/ including local files prefixed with smtpd/ are not found, including the source base directory takes care of that.