### PR TITLE
ci: ansible testing framework for freebsd build + alpine 3.11 on libressl

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -13,8 +13,11 @@ packages:
 - python37
 - python-3.7_3,2
 sources:
+- https://github.com/OpenSMTPD/OpenSMTPD
 - https://github.com/OpenSMTPD/ci
 tasks:
 - ansible: |
+    ls -lah
+    BUILD_DIR=$(pwd)/OpenSMTPD
     cd ci/ansible
-    ansible-playbook test.yml
+    ansible-playbook test.yml --skip-tags checkout --extra-vars "build_dir=$BUILD_DIR"

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -7,13 +7,14 @@ packages:
 - libtool
 - libressl
 - libasr
+- py37-ansible-2.8.7
+- db6
+- python3
+- python37
+- python-3.7_3,2
 sources:
-- https://github.com/OpenSMTPD/OpenSMTPD
+- https://github.com/OpenSMTPD/ci
 tasks:
-- configure: |
-    cd OpenSMTPD
-    ./bootstrap
-    ./configure --with-libasr=/usr/local
-- build: |
-    cd OpenSMTPD
-    make
+- ansible: |
+    cd ci/ansible
+    ansible-playbook test.yml

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -20,4 +20,4 @@ tasks:
     ls -lah
     BUILD_DIR=$(pwd)/OpenSMTPD
     cd ci/ansible
-    ansible-playbook test.yml --skip-tags checkout --extra-vars "build_dir=$BUILD_DIR"
+    ansible-playbook test.yml --inventory inventory/freebsd --skip-tags checkout --extra-vars "build_dir=$BUILD_DIR"

--- a/ci/docker/Dockerfile.alpine
+++ b/ci/docker/Dockerfile.alpine
@@ -1,10 +1,4 @@
-FROM alpine:3.10 as build
-
-# Allow container to expose ports at runtime, if necessary
-# https://docs.docker.com/engine/reference/#expose
-EXPOSE 25
-EXPOSE 465
-EXPOSE 587
+FROM alpine:3.11 as build
 
 # creates /opensmtpd dir and makes all following commands to run in it
 # https://docs.docker.com/engine/reference/builder/#workdir
@@ -26,8 +20,8 @@ RUN apk add --no-cache \
     linux-pam-dev \
     make \
     musl-dev \
-    openssl \
-    openssl-dev \
+    libressl \
+    libressl-dev \
     zlib-dev
  
 # create users and directories


### PR DESCRIPTION
Two things are going on here:
- FreeBSD build on SourceHut is now using my new ansible framework. It covers very small area at the moment - build and simple mail send to a local recipient, but it is easily extendible to include more tests or more platforms. I plan to include all linux builds in the nearest future.
- Alpine container upgraded to 3.11 (latest release) and switched to libressl