### PR TITLE
Use correct libexec path in portable man pages

### DIFF
--- a/mk/smtpd/Makefile.am
+++ b/mk/smtpd/Makefile.am
@@ -142,7 +142,8 @@ EXTRA_DIST+=		$(backends_srcdir)/queue_utils.h
 EXTRA_DIST+=		$(filters_srcdir)/asr_event.h
 
 PATHSUBS=		-e 's|/etc/mail/|$(sysconfdir)/|g'			\
-			-e 's|/var/run/smtpd.sock|$(sockdir)/smtpd.sock|g'
+			-e 's|/var/run/smtpd.sock|$(sockdir)/smtpd.sock|g' \
+			-e 's|/usr/local/libexec/smtpd/|$(pkglibexecdir)|g'
 
 FIXPATHSCMD=		$(SED) $(PATHSUBS)
 


### PR DESCRIPTION
smtpd.conf(5) in the portable branch refers to the directory `/usr/local/libexec/smtpd/`. This may not be the correct location on non-OpenBSD systems (it is not on Debian). Update the Makefile to update this location at compile time.