### PR TITLE
Do not install asr.h

### DIFF
--- a/openbsd-compat/Makefile.am
+++ b/openbsd-compat/Makefile.am
@@ -17,8 +17,6 @@ libopenbsd_a_SOURCES +=	libasr/getnameinfo_async.c
 libopenbsd_a_SOURCES +=	libasr/getnetnamadr_async.c
 libopenbsd_a_SOURCES +=	libasr/res_search_async.c
 libopenbsd_a_SOURCES +=	libasr/res_send_async.c
-
-include_HEADERS =	libasr/asr.h
 endif
 
 


### PR DESCRIPTION
From IRC:
```
09:34 < rak> opensmtpd 6.7.0p1 installs /usr/include/asr.h, but doesn't install the corresponding libasr.so file. Is usr/include/asr.h really meant to be installed, or is that a bug?
10:02 < __gilles> rak: its not meant to be installed, that's a bug
```