### PR TITLE
Replace link to the wiki with a link to the manual pages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ mailing list: http://www.opensmtpd.org/list.html
 
 and to join the IRC channel: #OpenSMTPD @ irc.freenode.net
 
-Also note that we have a wiki at
-https://github.com/OpenSMTPD/OpenSMTPD/wiki that you are encouraged to
-contribute to.
+The manual pages are available online at https://www.opensmtpd.org/manual.html,
+which you are encouraged to contribute to.
 
 Cheers!
 
@@ -145,7 +144,7 @@ script allows overriding these using the options:
 
 ### NetBSD, Linux (Debian, Arch Linux, ...)
 
-    mkdir /var/empty  
+    mkdir /var/empty
     useradd -c "SMTP Daemon" -d /var/empty -s /sbin/nologin _smtpd
     useradd -c "SMTPD Queue" -d /var/empty -s /sbin/nologin _smtpq
 


### PR DESCRIPTION
Turns out the wiki is disabled due to lack of contribution. This PR updates the link to the wiki to point to [the manual pages link on OpenSMTPD's website](https://www.opensmtpd.org/manual.html) instead.

Closes #1070

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensmtpd/opensmtpd/1071)
<!-- Reviewable:end -->
