### PR TITLE
fix bug with "smtpctl encrypt"

### DIFF
--- a/usr.sbin/smtpd/smtpctl.c
+++ b/usr.sbin/smtpd/smtpctl.c
@@ -966,7 +966,7 @@ do_encrypt(int argc, struct parameter *argv)
 
 	if (argv)
 		p = argv[0].u.u_str;
-	execl(PATH_ENCRYPT, "encrypt", "--", p, (char *)NULL);
+	execl(PATH_ENCRYPT, "encrypt", p, (char *)NULL);
 	errx(1, "execl");
 }
 


### PR DESCRIPTION
encrypt.c will exit if `argc > 2`. However, the code at smtpctl.c:L969 executes `encrypt` with wrong number of arguments when `p != NULL`, which leads to a bug that the program complains `usage: encrypt <string>` when we run `smtpctl encrypt some_string`.
The code  `"--", ` was involved in commit `4c624cc`. Before that commit, the code had always been `execl(PATH_ENCRYPT, "encrypt", p, (char *)NULL);`.