### PR TITLE
Fix out-of-tree build

### DIFF
--- a/mk/mail/mail.lmtp/Makefile.am
+++ b/mk/mail/mail.lmtp/Makefile.am
@@ -2,8 +2,8 @@ include	$(top_srcdir)/mk/pathnames
 
 pkglibexec_PROGRAMS =	mail.lmtp
 
-mail_lmtp_SOURCES = $(smtpd_srcdir)/mail.lmtp.c
-mail_lmtp_SOURCES+= $(smtpd_srcdir)/log.c
+mail_lmtp_SOURCES = $(top_srcdir)/usr.sbin/smtpd/mail.lmtp.c
+mail_lmtp_SOURCES+= $(top_srcdir)/usr.sbin/smtpd/log.c
 
 AM_CPPFLAGS=		-I$(top_srcdir)/smtpd			\
 			-I$(top_srcdir)/openbsd-compat

--- a/mk/mail/mail.maildir/Makefile.am
+++ b/mk/mail/mail.maildir/Makefile.am
@@ -2,8 +2,8 @@ include	$(top_srcdir)/mk/pathnames
 
 pkglibexec_PROGRAMS =	mail.maildir
 
-mail_maildir_SOURCES = $(smtpd_srcdir)/mail.maildir.c
-mail_maildir_SOURCES+= $(smtpd_srcdir)/log.c
+mail_maildir_SOURCES = $(top_srcdir)/usr.sbin/smtpd/mail.maildir.c
+mail_maildir_SOURCES+= $(top_srcdir)/usr.sbin/smtpd/log.c
 
 AM_CPPFLAGS=		-I$(top_srcdir)/smtpd			\
 			-I$(top_srcdir)/openbsd-compat

--- a/mk/mail/mail.mboxfile/Makefile.am
+++ b/mk/mail/mail.mboxfile/Makefile.am
@@ -2,8 +2,8 @@ include	$(top_srcdir)/mk/pathnames
 
 pkglibexec_PROGRAMS =	mail.mboxfile
 
-mail_mboxfile_SOURCES = $(smtpd_srcdir)/mail.mboxfile.c
-mail_mboxfile_SOURCES+= $(smtpd_srcdir)/log.c
+mail_mboxfile_SOURCES = $(top_srcdir)/usr.sbin/smtpd/mail.mboxfile.c
+mail_mboxfile_SOURCES+= $(top_srcdir)/usr.sbin/smtpd/log.c
 
 AM_CPPFLAGS=		-I$(top_srcdir)/smtpd			\
 			-I$(top_srcdir)/openbsd-compat

--- a/mk/mail/mail.mda/Makefile.am
+++ b/mk/mail/mail.mda/Makefile.am
@@ -2,8 +2,8 @@ include	$(top_srcdir)/mk/pathnames
 
 pkglibexec_PROGRAMS =	mail.mda
 
-mail_mda_SOURCES = $(smtpd_srcdir)/mail.mda.c
-mail_mda_SOURCES+= $(smtpd_srcdir)/log.c
+mail_mda_SOURCES = $(top_srcdir)/usr.sbin/smtpd/mail.mda.c
+mail_mda_SOURCES+= $(top_srcdir)/usr.sbin/smtpd/log.c
 
 AM_CPPFLAGS=		-I$(top_srcdir)/smtpd			\
 			-I$(top_srcdir)/openbsd-compat

--- a/mk/smtp/Makefile.am
+++ b/mk/smtp/Makefile.am
@@ -2,13 +2,13 @@ include	$(top_srcdir)/mk/pathnames
 
 bin_PROGRAMS=		smtp
 
-smtp_SOURCES=	$(smtpd_srcdir)/iobuf.c
-smtp_SOURCES+=	$(smtpd_srcdir)/ioev.c
-smtp_SOURCES+=	$(smtpd_srcdir)/log.c
-smtp_SOURCES+=	$(smtpd_srcdir)/smtp_client.c
-smtp_SOURCES+=	$(smtpd_srcdir)/smtpc.c
-smtp_SOURCES+=	$(smtpd_srcdir)/ssl.c
-smtp_SOURCES+=	$(smtpd_srcdir)/ssl_verify.c
+smtp_SOURCES=	$(top_srcdir)/usr.sbin/smtpd/iobuf.c
+smtp_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/ioev.c
+smtp_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/log.c
+smtp_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/smtp_client.c
+smtp_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/smtpc.c
+smtp_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/ssl.c
+smtp_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/ssl_verify.c
 
 smtp_CFLAGS=		-DIO_TLS
 
@@ -30,7 +30,7 @@ CFLAGS+=		-D_GNU_SOURCE
 CPPFLAGS=		-I$(srcdir) @CPPFLAGS@ $(PATHS) @DEFS@
 
 MANPAGES=		smtp.1.out
-MANPAGES_IN=		$(smtpd_srcdir)/smtp.1
+MANPAGES_IN=		$(top_srcdir)/usr.sbin/smtpd/smtp.1
 
 EXTRA_DIST=		$(MANPAGES_IN)
 
@@ -42,7 +42,7 @@ FIXPATHSCMD=		$(SED) $(PATHSUBS)
 
 
 $(MANPAGES): $(MANPAGES_IN)
-	manpage=$(smtpd_srcdir)/`echo $@ | sed 's/\.out$$//'`; \
+	manpage=$(top_srcdir)/usr.sbin/smtpd/`echo $@ | sed 's/\.out$$//'`; \
 	if test "$(MANTYPE)" = "man"; then \
 		$(FIXPATHSCMD) $${manpage} | $(AWK) -f $(srcdir)/../mdoc2man.awk > $@; \
 	else \

--- a/mk/smtpctl/Makefile.am
+++ b/mk/smtpctl/Makefile.am
@@ -2,37 +2,37 @@ include	$(top_srcdir)/mk/pathnames
 
 sbin_PROGRAMS=		smtpctl
 
-smtpctl_SOURCES=	$(smtpd_srcdir)/enqueue.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/parser.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/log.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/envelope.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/queue_backend.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/queue_fs.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/smtpctl.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/spfwalk.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/util.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/unpack_dns.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/compress_backend.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/compress_gzip.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/to.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/expand.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/tree.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/dict.c
+smtpctl_SOURCES=	$(top_srcdir)/usr.sbin/smtpd/enqueue.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/parser.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/log.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/envelope.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/queue_backend.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/queue_fs.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/smtpctl.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/spfwalk.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/util.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/unpack_dns.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/compress_backend.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/compress_gzip.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/to.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/expand.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/tree.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/dict.c
 
 if HAVE_DB_API
-smtpctl_SOURCES+=	$(smtpd_srcdir)/config.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/parse.y
-smtpctl_SOURCES+=	$(smtpd_srcdir)/limit.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/table.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/table_static.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/table_db.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/table_getpwnam.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/table_proc.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/mailaddr.c
-smtpctl_SOURCES+=	$(smtpd_srcdir)/makemap.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/config.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/parse.y
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/limit.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/table.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/table_static.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/table_db.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/table_getpwnam.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/table_proc.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/mailaddr.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/makemap.c
 endif
 
-smtpctl_SOURCES+=	$(smtpd_srcdir)/crypto.c
+smtpctl_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/crypto.c
 
 smtpctl_CFLAGS=		-DNO_IO -DCONFIG_MINIMUM
 smtpctl_CFLAGS+=	-DPATH_GZCAT=\"$(ZCAT)\" \
@@ -59,7 +59,7 @@ CFLAGS+=		-D_GNU_SOURCE
 CPPFLAGS=		-I$(srcdir) @CPPFLAGS@ $(PATHS) @DEFS@
 
 MANPAGES=		smtpctl.8.out sendmail.8.out makemap.8.out newaliases.8.out
-MANPAGES_IN=		$(smtpd_srcdir)/smtpctl.8 $(smtpd_srcdir)/sendmail.8 $(smtpd_srcdir)/makemap.8 $(smtpd_srcdir)/newaliases.8
+MANPAGES_IN=		$(top_srcdir)/usr.sbin/smtpd/smtpctl.8 $(top_srcdir)/usr.sbin/smtpd/sendmail.8 $(top_srcdir)/usr.sbin/smtpd/makemap.8 $(top_srcdir)/usr.sbin/smtpd/newaliases.8
 
 EXTRA_DIST=		$(MANPAGES_IN)
 
@@ -74,7 +74,7 @@ AM_CPPFLAGS+=	-I$(top_srcdir)/openbsd-compat/libasr
 endif
 
 $(MANPAGES): $(MANPAGES_IN)
-	manpage=$(smtpd_srcdir)/`echo $@ | sed 's/\.out$$//'`; \
+	manpage=$(top_srcdir)/usr.sbin/smtpd/`echo $@ | sed 's/\.out$$//'`; \
 	if test "$(MANTYPE)" = "man"; then \
 		$(FIXPATHSCMD) $${manpage} | $(AWK) -f $(srcdir)/../mdoc2man.awk > $@; \
 	else \

--- a/mk/smtpd/Makefile.am
+++ b/mk/smtpd/Makefile.am
@@ -14,84 +14,84 @@ include $(top_srcdir)/mk/pathnames
 
 sbin_PROGRAMS=		smtpd
 
-smtpd_SOURCES=		$(smtpd_srcdir)/aliases.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/bounce.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/ca.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/cert.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/compress_backend.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/config.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/control.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/dict.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/dns.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/esc.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/envelope.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/expand.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/forward.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/iobuf.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/ioev.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/limit.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/lka.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/lka_filter.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/lka_session.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/log.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/mda.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/mda_mbox.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/mda_unpriv.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/mda_variables.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/mproc.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/mailaddr.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/mta.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/mta_session.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/parse.y
-smtpd_SOURCES+=		$(smtpd_srcdir)/pony.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/proxy.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/queue.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/queue_backend.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/report_smtp.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/resolver.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/rfc5322.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/ruleset.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/runq.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/scheduler.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/scheduler_backend.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/smtp.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/smtp_session.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/smtpd.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/srs.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/ssl.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/ssl_smtpd.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/ssl_verify.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/stat_backend.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/table.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/to.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/tree.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/unpack_dns.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/util.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/waitq.c
+smtpd_SOURCES=		$(top_srcdir)/usr.sbin/smtpd/aliases.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/bounce.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/ca.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/cert.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/compress_backend.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/config.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/control.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/dict.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/dns.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/esc.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/envelope.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/expand.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/forward.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/iobuf.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/limit.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/lka.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/lka_filter.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/lka_session.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/log.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/mda.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/mda_mbox.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/mda_unpriv.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/mda_variables.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/mproc.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/mailaddr.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/mta.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/mta_session.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/parse.y
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/pony.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/proxy.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/queue.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/queue_backend.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/report_smtp.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/resolver.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/rfc5322.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/ruleset.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/runq.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/scheduler.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/scheduler_backend.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/smtp.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/smtp_session.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/smtpd.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/srs.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/ssl.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/ssl_smtpd.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/ssl_verify.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/stat_backend.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/table.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/to.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/tree.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/unpack_dns.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/util.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/waitq.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/ioev.c
 
 # backends
-smtpd_SOURCES+=		$(smtpd_srcdir)/crypto.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/compress_gzip.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/crypto.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/compress_gzip.c
 if HAVE_DB_API
-smtpd_SOURCES+=		$(smtpd_srcdir)/table_db.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/table_db.c
 endif
-smtpd_SOURCES+=		$(smtpd_srcdir)/table_getpwnam.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/table_proc.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/table_static.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/queue_fs.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/queue_null.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/queue_proc.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/queue_ram.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/scheduler_null.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/scheduler_proc.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/scheduler_ramqueue.c
-smtpd_SOURCES+=		$(smtpd_srcdir)/stat_ramstat.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/table_getpwnam.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/table_proc.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/table_static.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/queue_fs.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/queue_null.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/queue_proc.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/queue_ram.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/scheduler_null.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/scheduler_proc.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/scheduler_ramqueue.c
+smtpd_SOURCES+=		$(top_srcdir)/usr.sbin/smtpd/stat_ramstat.c
 
 
 smtpd_CFLAGS=		-DIO_TLS
 smtpd_CFLAGS+=		-DCA_FILE=\"$(CA_FILE)\"
 
-AM_CPPFLAGS=		-I$(smtpd_srcdir)	\
+AM_CPPFLAGS=		-I$(top_srcdir)/usr.sbin/smtpd	\
 			-I$(compat_srcdir)
 if !NEED_ERR_H
 AM_CPPFLAGS += -I$(top_srcdir)/openbsd-compat/err_h
@@ -111,35 +111,37 @@ LDADD=			$(LIBCOMPAT) $(DB_LIB) $(ASR_LIB)
 # EAI_NODATA defined
 # {v,}asprintf
 # setres{g,u}id
-CFLAGS+=		-D_GNU_SOURCE -DNEED_EVENT_ASR_RUN
-CPPFLAGS=		-I$(srcdir) @CPPFLAGS@ $(PATHS) @DEFS@
+AM_CFLAGS=		-D_GNU_SOURCE -DNEED_EVENT_ASR_RUN
+AM_CPPFLAGS+=		-I$(srcdir) $(PATHS) @DEFS@
 
 MANPAGES=		aliases.5.out forward.5.out smtpd.8.out	\
 			smtpd.conf.5.out table.5.out
 
-MANPAGES_IN=		$(smtpd_srcdir)/aliases.5
-MANPAGES_IN+=		$(smtpd_srcdir)/forward.5
-MANPAGES_IN+=		$(smtpd_srcdir)/smtpd.8
-MANPAGES_IN+=		$(smtpd_srcdir)/smtpd.conf.5
-MANPAGES_IN+=		$(smtpd_srcdir)/table.5
+MANPAGES_IN=		$(top_srcdir)/usr.sbin/smtpd/aliases.5
+MANPAGES_IN+=		$(top_srcdir)/usr.sbin/smtpd/forward.5
+MANPAGES_IN+=		$(top_srcdir)/usr.sbin/smtpd/smtpd.8
+MANPAGES_IN+=		$(top_srcdir)/usr.sbin/smtpd/smtpd.conf.5
+MANPAGES_IN+=		$(top_srcdir)/usr.sbin/smtpd/table.5
 
 CONFIGFILES=		smtpd.conf.out
-CONFIGFILES_IN=		$(smtpd_srcdir)/smtpd.conf
+CONFIGFILES_IN=		$(top_srcdir)/usr.sbin/smtpd/smtpd.conf
 
 EXTRA_DIST=		$(CONFIGFILES_IN) $(MANPAGES_IN)
 
 
-EXTRA_DIST+=		$(smtpd_srcdir)/smtpd.h
-EXTRA_DIST+=		$(smtpd_srcdir)/smtpd-api.h
-EXTRA_DIST+=		$(smtpd_srcdir)/smtpd-defines.h
-EXTRA_DIST+=		$(smtpd_srcdir)/ioev.h
-EXTRA_DIST+=		$(smtpd_srcdir)/iobuf.h
-EXTRA_DIST+=		$(smtpd_srcdir)/log.h
-EXTRA_DIST+=		$(smtpd_srcdir)/ssl.h
-EXTRA_DIST+=		$(smtpd_srcdir)/parser.h
-
-EXTRA_DIST+=		$(backends_srcdir)/queue_utils.h
-EXTRA_DIST+=		$(filters_srcdir)/asr_event.h
+EXTRA_DIST+=		$(top_srcdir)/usr.sbin/smtpd/rfc5322.h
+EXTRA_DIST+=		$(top_srcdir)/usr.sbin/smtpd/unpack_dns.h
+EXTRA_DIST+=		$(top_srcdir)/usr.sbin/smtpd/tree.h
+EXTRA_DIST+=		$(top_srcdir)/usr.sbin/smtpd/smtp.h
+EXTRA_DIST+=		$(top_srcdir)/usr.sbin/smtpd/smtpd.h
+EXTRA_DIST+=		$(top_srcdir)/usr.sbin/smtpd/smtpd-api.h
+EXTRA_DIST+=		$(top_srcdir)/usr.sbin/smtpd/smtpd-defines.h
+EXTRA_DIST+=		$(top_srcdir)/usr.sbin/smtpd/ioev.h
+EXTRA_DIST+=		$(top_srcdir)/usr.sbin/smtpd/iobuf.h
+EXTRA_DIST+=		$(top_srcdir)/usr.sbin/smtpd/log.h
+EXTRA_DIST+=		$(top_srcdir)/usr.sbin/smtpd/ssl.h
+EXTRA_DIST+=		$(top_srcdir)/usr.sbin/smtpd/parser.h
+EXTRA_DIST+=		$(top_srcdir)/usr.sbin/smtpd/dict.h
 
 PATHSUBS=		-e 's|/etc/mail/|$(sysconfdir)/|g'			\
 			-e 's|/var/run/smtpd.sock|$(sockdir)/smtpd.sock|g' \
@@ -148,7 +150,7 @@ PATHSUBS=		-e 's|/etc/mail/|$(sysconfdir)/|g'			\
 FIXPATHSCMD=		$(SED) $(PATHSUBS)
 
 $(MANPAGES): $(MANPAGES_IN)
-	manpage=$(smtpd_srcdir)/`echo $@ | sed 's/\.out$$//'`; \
+	manpage=$(top_srcdir)/usr.sbin/smtpd/`echo $@ | sed 's/\.out$$//'`; \
 	if test "$(MANTYPE)" = "man"; then \
 		$(FIXPATHSCMD) $${manpage} | $(AWK) -f $(srcdir)/../mdoc2man.awk > $@; \
 	else \
@@ -156,8 +158,8 @@ $(MANPAGES): $(MANPAGES_IN)
 	fi
 
 $(CONFIGFILES): $(CONFIGFILES_IN)
-	conffile=$(smtpd_srcdir)/`echo $@ | sed 's/.out$$//'`; \
-	$(CAT) $(srcdir)/$${conffile} > $@
+	conffile=$(top_srcdir)/usr.sbin/smtpd/`echo $@ | sed 's/.out$$//'`; \
+	$(CAT) $${conffile} > $@
 
 
 # smtpd.conf
@@ -184,8 +186,8 @@ install-exec-hook: $(CONFIGFILES) $(MANPAGES)
 
 uninstall-hook:
 # XXX to make "make distcheck" happy we need to rm smtpd.conf
-#	rm $(DESTDIR)$(sysconfdir)/smtpd.conf
-	rm -f	$(DESTDIR)$(mandir)/$(mansubdir)5/aliases.5			\
+	rm -f	$(DESTDIR)$(sysconfdir)/smtpd.conf				\
+		$(DESTDIR)$(mandir)/$(mansubdir)5/aliases.5			\
 		$(DESTDIR)$(mandir)/$(mansubdir)5/forward.5			\
 		$(DESTDIR)$(mandir)/$(mansubdir)5/table.5			\
 		$(DESTDIR)$(mandir)/$(mansubdir)5/smtpd.conf.5			\

--- a/openbsd-compat/Makefile.am
+++ b/openbsd-compat/Makefile.am
@@ -216,7 +216,7 @@ EXTRA_DIST +=	defines.h
 EXTRA_DIST +=	entropy.h
 EXTRA_DIST +=	imsg.h
 EXTRA_DIST +=	includes.h
-EXTRA_DIST +=	log.h
+EXTRA_DIST +=	$(top_srcdir)/usr.sbin/smtpd/log.h
 EXTRA_DIST +=	openbsd-compat.h
 EXTRA_DIST +=	sys/queue.h
 EXTRA_DIST +=	sys/tree.h
@@ -225,6 +225,8 @@ EXTRA_DIST +=	bsd-vis.h
 if NEED_LIBASR
 EXTRA_DIST +=		libasr/asr_compat.h
 EXTRA_DIST +=		libasr/asr_private.h
+EXTRA_DIST +=		libasr/asr.h
+EXTRA_DIST +=		libasr/thread_private.h
 endif
 
 


### PR DESCRIPTION
Automake treats $(top_srcdir) specially, so a variable that expands to
it won't work.  There were also bugs in the Makefile.am files that broke
`make distcheck`