### PR TITLE
Fix get_progname() issues.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2041,8 +2041,6 @@ AM_CONDITIONAL([NEED_RES_RANDOMID], [test "x$ac_cv_search_res_randomid" = "xno" 
 
 AM_CONDITIONAL([NEED_ARC4RANDOM], [test "x$ac_cv_func_arc4random" != "xyes" -a "x$ac_cv_have_decl_LIBRESSL_VERSION_NUMBER" != "xyes"])
 AM_CONDITIONAL([NEED_SSL_CTX_USE_CERTIFICATE_CHAIN_MEM], [test "x$ac_cv_have_decl_LIBRESSL_VERSION_NUMBER" != "xyes"])
-
-AM_CONDITIONAL([NEED_PROGNAME], [test "x$ac_cv_libc_defines___progname" != "xyes"])
 ##
 
 

--- a/openbsd-compat/Makefile.am
+++ b/openbsd-compat/Makefile.am
@@ -3,6 +3,7 @@ noinst_LIBRARIES = libopenbsd.a
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/usr.sbin/smtpd -I$(top_srcdir)/openbsd-compat
 
 libopenbsd_a_SOURCES =	empty.c
+libopenbsd_a_SOURCES +=	progname.c
 
 if NEED_LIBASR
 AM_CPPFLAGS += -I$(top_srcdir)/openbsd-compat/libasr
@@ -17,12 +18,6 @@ libopenbsd_a_SOURCES +=	libasr/getnameinfo_async.c
 libopenbsd_a_SOURCES +=	libasr/getnetnamadr_async.c
 libopenbsd_a_SOURCES +=	libasr/res_search_async.c
 libopenbsd_a_SOURCES +=	libasr/res_send_async.c
-endif
-
-
-
-if NEED_PROGNAME
-libopenbsd_a_SOURCES +=	progname.c
 endif
 
 if NEED_ARC4RANDOM

--- a/usr.sbin/smtpd/smtpctl.c
+++ b/usr.sbin/smtpd/smtpctl.c
@@ -1066,9 +1066,7 @@ main(int argc, char **argv)
 	int		 privileged;
 	char		*argv_mailq[] = { "show", "queue", NULL };
 
-#ifndef HAVE___PROGNAME
-	__progname = ssh_get_progname(argv[0]);
-#endif
+	__progname = get_progname(argv[0]);
 
 	/* check that smtpctl was installed setgid */
 	if ((gr = getgrnam(SMTPD_QUEUE_GROUP)) == NULL)

--- a/usr.sbin/smtpd/smtpd.c
+++ b/usr.sbin/smtpd/smtpd.c
@@ -519,9 +519,7 @@ main(int argc, char *argv[])
 	char		*rexec = NULL;
 	struct smtpd	*conf;
 
-#ifndef HAVE___PROGNAME
-	__progname = ssh_get_progname(argv[0]);
-#endif
+	__progname = get_progname(argv[0]);
 
 #ifndef HAVE_SETPROCTITLE
 	/* Save argv. Duplicate so setproctitle emulation doesn't clobber it */


### PR DESCRIPTION
Fix for https://github.com/OpenSMTPD/OpenSMTPD/issues/1059

Apparently libc __progname doesn't give the same result as get_progname() from openbsd-compat.