### PR TITLE
Don't mention OpenBSD interface 'all' in portable smtpd.conf

### DIFF
--- a/usr.sbin/smtpd/smtpd.conf
+++ b/usr.sbin/smtpd/smtpd.conf
@@ -5,8 +5,11 @@
 
 table aliases file:/etc/mail/aliases
 
-# To accept external mail, replace with: listen on all
+# To also accept external mail over IPv4 or IPv6,
+# respectively replace "listen on localhost" with:
 #
+# listen on 0.0.0.0
+# listen on ::
 listen on localhost
 
 action "local" maildir alias <aliases>


### PR DESCRIPTION
OpenBSD has an "all" interface group that includes all interfaces
(ifconfig(8)), but this interface group does not exist on other systems.
As a result, it doesn't make sense to discuss listening on this
interface in the portable version of OpenSMTPD. Instead, we should
suggest that users listen on the meta-addresses 0.0.0.0 and :: if they
want to receive mail on all interfaces.

Closes: https://bugs.debian.org/963252