### PR TITLE
configure.ac: Fix man page location.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1012,9 +1012,9 @@ AC_ARG_WITH([mantype],
 if test -z "$MANTYPE"; then
 	TestPath="/usr/bin${PATH_SEPARATOR}/usr/ucb"
 	AC_PATH_PROGS([NROFF], [nroff awf], [/bin/false], [$TestPath])
-	if ${NROFF} -mdoc ${srcdir}/smtpd/smtpd.8 >/dev/null 2>&1; then
+	if ${NROFF} -mdoc ${srcdir}/usr.sbin/smtpd/smtpd.8 >/dev/null 2>&1; then
 		MANTYPE=doc
-	elif ${NROFF} -man ${srcdir}/smtpd/smtpd.8 >/dev/null 2>&1; then
+	elif ${NROFF} -man ${srcdir}/usr.sbin/smtpd/smtpd.8 >/dev/null 2>&1; then
 		MANTYPE=man
 	else
 		MANTYPE=cat


### PR DESCRIPTION
Running ${NROFF} on a nonexistent file always fails, leading to the
man pages being instealled to /share/man/catN instead of manN.

This follows up on commit 054cadd5524759b57aefb39659356552091118d9.