### PR TITLE
Fix broken FBSD CI build

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -8,7 +8,7 @@ packages:
 - libressl
 - libasr
 - py37-ansible
-- db6
+- db5
 - python3
 - python37
 - python


### PR DESCRIPTION
db6 package was removed from ports tree due to it is no longer
downloadable without registration. It is recommended to use db5 instead.

https://www.freshports.org/databases/db6