### PR TITLE
remove ssl_verify.c from build process

### DIFF
--- a/mk/smtp/Makefile.am
+++ b/mk/smtp/Makefile.am
@@ -8,7 +8,6 @@ smtp_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/log.c
 smtp_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/smtp_client.c
 smtp_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/smtpc.c
 smtp_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/ssl.c
-smtp_SOURCES+=	$(top_srcdir)/usr.sbin/smtpd/ssl_verify.c
 
 smtp_CFLAGS=		-DIO_TLS
 


### PR DESCRIPTION
ssl_verify.c isn't part of the sources anymore