### PR TITLE
Check if IN6_IS_ADDR_MC_INTFACELOCAL is available. Use IN6_IS_ADDR_MC…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -384,6 +384,7 @@ AC_CHECK_DECLS([IPPORT_HILASTAUTO], [], [], [
 
 AC_CHECK_DECLS([IPV6_ADDR_SCOPE_INTFACELOCAL], [], [], [
 #include <netinet6/in6.h>
+#include <netinet/in.h>
 ])
 
 AC_CHECK_DECLS([WAIT_MYPGRP], [], [], [

--- a/configure.ac
+++ b/configure.ac
@@ -382,6 +382,10 @@ AC_CHECK_DECLS([IPPORT_HILASTAUTO], [], [], [
 #include <netinet/in.h>
 ])
 
+AC_CHECK_DECLS([IPV6_ADDR_SCOPE_INTFACELOCAL], [], [], [
+#include <netinet6/in6.h>
+])
+
 AC_CHECK_DECLS([WAIT_MYPGRP], [], [], [
 #include <sys/wait.h>
 ])

--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -263,6 +263,10 @@ int res_hnok(const char *);
 #define IPPORT_HILASTAUTO 65535
 #endif
 
+#if !HAVE_DECL_IPV6_ADDR_SCOPE_INTFACELOCAL
+#define USE_IPV6_ADDR_SCOPE_NODELOCAL 1
+#endif
+
 #ifndef HAVE_FLOCK
 int flock(int, int);
 #endif

--- a/usr.sbin/smtpd/config.c
+++ b/usr.sbin/smtpd/config.c
@@ -215,7 +215,11 @@ set_localaddrs(struct smtpd *conf, struct table *localnames)
 #ifdef __KAME__
 			if ((IN6_IS_ADDR_LINKLOCAL(&sin6->sin6_addr) ||
 			    IN6_IS_ADDR_MC_LINKLOCAL(&sin6->sin6_addr) ||
+#ifdef USE_IPV6_ADDR_SCOPE_NODELOCAL
+			    IN6_IS_ADDR_MC_NODELOCAL(&sin6->sin6_addr)) &&
+#else
 			    IN6_IS_ADDR_MC_INTFACELOCAL(&sin6->sin6_addr)) &&
+#endif
 			    sin6->sin6_scope_id == 0) {
 				sin6->sin6_scope_id = ntohs(
 				    *(u_int16_t *)&sin6->sin6_addr.s6_addr[2]);

--- a/usr.sbin/smtpd/parse.y
+++ b/usr.sbin/smtpd/parse.y
@@ -3539,7 +3539,11 @@ interface(struct listen_opts *lo)
 #ifdef __KAME__
 			if ((IN6_IS_ADDR_LINKLOCAL(&sin6->sin6_addr) ||
 			    IN6_IS_ADDR_MC_LINKLOCAL(&sin6->sin6_addr) ||
+#ifdef USE_IPV6_ADDR_SCOPE_NODELOCAL
+			    IN6_IS_ADDR_MC_NODELOCAL(&sin6->sin6_addr)) &&
+#else
 			    IN6_IS_ADDR_MC_INTFACELOCAL(&sin6->sin6_addr)) &&
+#endif
 			    sin6->sin6_scope_id == 0) {
 				sin6->sin6_scope_id = ntohs(
 				    *(u_int16_t *)&sin6->sin6_addr.s6_addr[2]);


### PR DESCRIPTION
macro IN6_IS_ADDR_MC_INTFACELOCAL is available only on openbsd. freebsd, netbsd and linux use IN6_IS_ADDR_MC_NODELOCAL