### PR TITLE
Avoid truncation of filtered SMTP Data to 1997 bytes.

### DIFF
--- a/usr.sbin/smtpd/lka_filter.c
+++ b/usr.sbin/smtpd/lka_filter.c
@@ -35,6 +35,8 @@
 
 #define	PROTOCOL_VERSION	"0.6"
 
+#define RESPONSE_LEN_MAX	(SMTP_LINE_MAX + 256)
+
 struct filter;
 struct filter_session;
 static void	filter_protocol_internal(struct filter_session *, uint64_t *, uint64_t, enum filter_phase, const char *);
@@ -602,7 +604,7 @@ lka_filter_process_response(const char *name, const char *line)
 {
 	uint64_t reqid;
 	uint64_t token;
-	char buffer[LINE_MAX];
+	char buffer[RESPONSE_LEN_MAX];
 	char *ep = NULL;
 	char *kind = NULL;
 	char *qid = NULL;

--- a/usr.sbin/smtpd/smtp_session.c
+++ b/usr.sbin/smtpd/smtp_session.c
@@ -46,7 +46,6 @@
 #include "log.h"
 #include "rfc5322.h"
 
-#define	SMTP_LINE_MAX			65535
 #define	DATA_HIWAT			65535
 #define	APPEND_DOMAIN_BUFFER_SIZE	SMTP_LINE_MAX
 

--- a/usr.sbin/smtpd/smtpd.h
+++ b/usr.sbin/smtpd/smtpd.h
@@ -49,6 +49,8 @@
 	   	    (expected_sz), (imsg)->hdr.len - IMSG_HEADER_SIZE);	\
 } while (0)
 
+#define SMTP_LINE_MAX		 65535
+
 #ifndef SMTPD_CONFDIR
 #define SMTPD_CONFDIR		 "/etc"
 #endif


### PR DESCRIPTION
When using smtpd filters (e.g. rspamd) data lines get truncated after 1997 bytes: When smtpd reads the lines from the filter it truncates them because the character buffer has only LINE_MAX (2048 Bytes on OpenBSD, FreeBSD and Linux).
This patch avoids this truncation.
Greetings,
Joachim