### PR TITLE
build: Fix -Werror=implicit-function-declaration

### DIFF
--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -92,6 +92,10 @@ int	scan_scaled(char *, long long *);
 const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
 #endif
 
+#ifndef HAVE_RES_RANDOMID
+unsigned int res_randomid(void);
+#endif
+
 #ifndef HAVE_STRSEP
 char *strsep(char **stringp, const char *delim);
 #endif

--- a/usr.sbin/smtpd/mail.maildir.c
+++ b/usr.sbin/smtpd/mail.maildir.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sysexits.h>
+#include <time.h>
 #include <unistd.h>
 
 #define	MAILADDR_ESCAPE		"!#$%&'*/?^`{|}~"

--- a/usr.sbin/smtpd/parse.y
+++ b/usr.sbin/smtpd/parse.y
@@ -44,6 +44,8 @@
 #include <netdb.h>
 #include <pwd.h>
 #include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
 #include <resolv.h>
 #include <syslog.h>
 #include <unistd.h>

--- a/usr.sbin/smtpd/smtpd.c
+++ b/usr.sbin/smtpd/smtpd.c
@@ -44,6 +44,7 @@
 #include <crypt.h> /* needed for crypt() */
 #endif
 #include <dirent.h>
+#include <err.h> /* needed for err and errx */
 #include <errno.h>
 #include <fcntl.h>
 #include <grp.h> /* needed for setgroups */


### PR DESCRIPTION
This has two commits.

1.

On a system with musl these functions are not available, but they are found by the build system inside of libbsd instead. However many of the relevant headers are never incuded resulting in many implicit function declarations. Additionally clang-16 is more strict about these turning them into errors.

2.

Split into PR https://github.com/OpenSMTPD/OpenSMTPD/pull/1198.