### PR TITLE
configure.ac: Check for crypt_gensalt()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -543,11 +543,11 @@ AC_SEARCH_LIBS([setsockopt],
 			[Define if you have the setsockopt() function.])
 	])
 
-AC_SEARCH_LIBS([crypt],
+AC_SEARCH_LIBS([crypt_gensalt],
 	[crypt],
 	[
-		AC_DEFINE([HAVE_CRYPT], [1],
-			[Define if you have the crypt() function.])
+		AC_DEFINE([HAVE_CRYPT_GENSALT], [1],
+			[Define if you have the crypt_gensalt() function.])
 	])
 
 AC_SEARCH_LIBS([imsg_init],


### PR DESCRIPTION
On musl systems `crypt()` is provided by `unistd.h` and it is marked as `"none required"` during the configure process. This results in `-lcrypt` never being passed to the compiler and then an undefined reference for `crypt_gensalt()`. This can be solved by checking for `crypt_gensalt()` instead.