### PR TITLE
build: Fix -Werror=strict-prototypes

### DIFF
--- a/usr.sbin/smtpd/bounce.c
+++ b/usr.sbin/smtpd/bounce.c
@@ -243,7 +243,7 @@ bounce_timeout(int fd, short ev, void *arg)
 }
 
 static void
-bounce_drain()
+bounce_drain(void)
 {
 	struct bounce_message	*msg;
 	struct timeval		 tv;

--- a/usr.sbin/smtpd/ioev.c
+++ b/usr.sbin/smtpd/ioev.c
@@ -228,7 +228,7 @@ io_frame_leave(struct io *io)
 }
 
 void
-_io_init()
+_io_init(void)
 {
 	static int init = 0;
 

--- a/usr.sbin/smtpd/mda.c
+++ b/usr.sbin/smtpd/mda.c
@@ -386,12 +386,12 @@ mda_imsg(struct mproc *p, struct imsg *imsg)
 }
 
 void
-mda_postfork()
+mda_postfork(void)
 {
 }
 
 void
-mda_postprivdrop()
+mda_postprivdrop(void)
 {
 	tree_init(&sessions);
 	tree_init(&users);

--- a/usr.sbin/smtpd/smtpd.c
+++ b/usr.sbin/smtpd/smtpd.c
@@ -353,7 +353,7 @@ parent_send_config_dispatcher(void)
 }
 
 void
-parent_send_config_lka()
+parent_send_config_lka(void)
 {
 	log_debug("debug: parent_send_config_ruleset: reloading");
 	m_compose(p_lka, IMSG_CONF_START, 0, 0, -1, NULL, 0);


### PR DESCRIPTION
Clang-16 is more strict about these so make the compiler happy.

Split from PR https://github.com/OpenSMTPD/OpenSMTPD/pull/1195.