### PR TITLE
sync with CVS

### DIFF
--- a/usr.sbin/smtpd/bounce.c
+++ b/usr.sbin/smtpd/bounce.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: bounce.c,v 1.86 2021/07/28 19:39:50 benno Exp $	*/
+/*	$OpenBSD: bounce.c,v 1.87 2023/02/08 08:20:54 tb Exp $	*/
 
 /*
  * Copyright (c) 2009 Gilles Chehade <gilles@poolp.org>
@@ -243,7 +243,7 @@ bounce_timeout(int fd, short ev, void *arg)
 }
 
 static void
-bounce_drain()
+bounce_drain(void)
 {
 	struct bounce_message	*msg;
 	struct timeval		 tv;

--- a/usr.sbin/smtpd/bounce.c
+++ b/usr.sbin/smtpd/bounce.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: bounce.c,v 1.87 2023/02/08 08:20:54 tb Exp $	*/
+/*	$OpenBSD: bounce.c,v 1.88 2023/05/04 12:43:44 chrisz Exp $	*/
 
 /*
  * Copyright (c) 2009 Gilles Chehade <gilles@poolp.org>
@@ -545,8 +545,8 @@ bounce_next(struct bounce_session *s)
 			if ((len = getline(&line, &sz, s->msgfp)) == -1)
 				break;
 			if (len == 1 && line[0] == '\n' && /* end of headers */
-			    s->msg->bounce.type == B_DELIVERED &&
-			    s->msg->bounce.dsn_ret ==  DSN_RETHDRS) {
+			    (s->msg->bounce.type != B_FAILED ||
+			    s->msg->bounce.dsn_ret != DSN_RETFULL)) {
 				free(line);
 				fclose(s->msgfp);
 				s->msgfp = NULL;

--- a/usr.sbin/smtpd/ca.c
+++ b/usr.sbin/smtpd/ca.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: ca.c,v 1.42 2022/02/18 16:57:36 millert Exp $	*/
+/*	$OpenBSD: ca.c,v 1.43 2023/03/26 18:11:48 tb Exp $	*/
 
 /*
  * Copyright (c) 2014 Reyk Floeter <reyk@openbsd.org>
@@ -29,6 +29,7 @@
 #include <imsg.h>
 #include <limits.h>
 
+#include <openssl/err.h>
 #include <openssl/pem.h>
 #include <openssl/engine.h>
 

--- a/usr.sbin/smtpd/control.c
+++ b/usr.sbin/smtpd/control.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: control.c,v 1.128 2021/06/14 17:58:15 eric Exp $	*/
+/*	$OpenBSD: control.c,v 1.129 2023/03/08 04:43:15 guenther Exp $	*/
 
 /*
  * Copyright (c) 2012 Gilles Chehade <gilles@poolp.org>
@@ -280,7 +280,6 @@ control_listen(void)
 	event_add(&control_state.ev, NULL);
 }
 
-/* ARGSUSED */
 static void
 control_accept(int listenfd, short event, void *arg)
 {
@@ -428,7 +427,6 @@ control_digest_update(const char *key, size_t value, int incr)
 	}
 }
 
-/* ARGSUSED */
 static void
 control_dispatch_ext(struct mproc *p, struct imsg *imsg)
 {

--- a/usr.sbin/smtpd/envelope.c
+++ b/usr.sbin/smtpd/envelope.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: envelope.c,v 1.49 2021/06/14 17:58:15 eric Exp $	*/
+/*	$OpenBSD: envelope.c,v 1.50 2022/09/24 17:08:32 millert Exp $	*/
 
 /*
  * Copyright (c) 2013 Eric Faurot <eric@openbsd.org>
@@ -287,16 +287,6 @@ ascii_load_sockaddr(struct sockaddr_storage *ss, char *buf)
 
 	if (!strcmp("local", buf)) {
 		ss->ss_family = AF_LOCAL;
-	}
-	else if (strncasecmp("IPv6:", buf, 5) == 0) {
-		/* XXX - remove this after 6.6 release */
-		if (inet_pton(AF_INET6, buf + 5, &ssin6.sin6_addr) != 1)
-			return 0;
-		ssin6.sin6_family = AF_INET6;
-		memcpy(ss, &ssin6, sizeof(ssin6));
-#ifdef HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN
-		ss->ss_len = sizeof(struct sockaddr_in6);
-#endif
 	}
 	else if (buf[0] == '[' && buf[strlen(buf)-1] == ']') {
 		buf[strlen(buf)-1] = '\0';

--- a/usr.sbin/smtpd/envelope.c
+++ b/usr.sbin/smtpd/envelope.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: envelope.c,v 1.50 2022/09/24 17:08:32 millert Exp $	*/
+/*	$OpenBSD: envelope.c,v 1.51 2023/02/06 18:35:52 semarie Exp $	*/
 
 /*
  * Copyright (c) 2013 Eric Faurot <eric@openbsd.org>
@@ -279,26 +279,30 @@ ascii_load_string(char *dest, char *buf, size_t len)
 static int
 ascii_load_sockaddr(struct sockaddr_storage *ss, char *buf)
 {
-	struct sockaddr_in6 ssin6;
-	struct sockaddr_in  ssin;
-
-	memset(&ssin, 0, sizeof ssin);
-	memset(&ssin6, 0, sizeof ssin6);
-
 	if (!strcmp("local", buf)) {
 		ss->ss_family = AF_LOCAL;
 	}
 	else if (buf[0] == '[' && buf[strlen(buf)-1] == ']') {
+		struct addrinfo hints, *res0;
+		
 		buf[strlen(buf)-1] = '\0';
-		if (inet_pton(AF_INET6, buf+1, &ssin6.sin6_addr) != 1)
+
+		/* getaddrinfo() is used to support scoped addresses. */
+		memset(&hints, 0, sizeof(hints));
+		hints.ai_family = AF_INET6;
+		hints.ai_flags = AI_NUMERICHOST;
+		if (getaddrinfo(buf+1, NULL, &hints, &res0) != 0)
 			return 0;
-		ssin6.sin6_family = AF_INET6;
-		memcpy(ss, &ssin6, sizeof(ssin6));
+		memcpy(ss, res0->ai_addr, res0->ai_addrlen);
 #ifdef HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN
-		ss->ss_len = sizeof(struct sockaddr_in6);
+		ss->ss_len = res0->ai_addrlen;
 #endif
+		freeaddrinfo(res0);
 	}
 	else {
+		struct sockaddr_in ssin;
+
+		memset(&ssin, 0, sizeof ssin);
 		if (inet_pton(AF_INET, buf, &ssin.sin_addr) != 1)
 			return 0;
 		ssin.sin_family = AF_INET;

--- a/usr.sbin/smtpd/ioev.c
+++ b/usr.sbin/smtpd/ioev.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: ioev.c,v 1.48 2021/06/14 17:58:15 eric Exp $	*/
+/*	$OpenBSD: ioev.c,v 1.49 2023/02/08 08:20:54 tb Exp $	*/
 /*
  * Copyright (c) 2012 Eric Faurot <eric@openbsd.org>
  *
@@ -228,7 +228,7 @@ io_frame_leave(struct io *io)
 }
 
 void
-_io_init()
+_io_init(void)
 {
 	static int init = 0;
 

--- a/usr.sbin/smtpd/mda.c
+++ b/usr.sbin/smtpd/mda.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: mda.c,v 1.143 2021/06/14 17:58:15 eric Exp $	*/
+/*	$OpenBSD: mda.c,v 1.144 2023/02/08 08:20:54 tb Exp $	*/
 
 /*
  * Copyright (c) 2008 Gilles Chehade <gilles@poolp.org>
@@ -386,12 +386,12 @@ mda_imsg(struct mproc *p, struct imsg *imsg)
 }
 
 void
-mda_postfork()
+mda_postfork(void)
 {
 }
 
 void
-mda_postprivdrop()
+mda_postprivdrop(void)
 {
 	tree_init(&sessions);
 	tree_init(&users);

--- a/usr.sbin/smtpd/mda_variables.c
+++ b/usr.sbin/smtpd/mda_variables.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: mda_variables.c,v 1.7 2021/06/14 17:58:15 eric Exp $	*/
+/*	$OpenBSD: mda_variables.c,v 1.8 2023/03/19 01:43:11 millert Exp $	*/
 
 /*
  * Copyright (c) 2011-2017 Gilles Chehade <gilles@poolp.org>
@@ -62,7 +62,7 @@ mda_expand_token(char *dest, size_t len, const char *token,
 {
 	char		rtoken[MAXTOKENLEN];
 	char		tmp[EXPAND_BUFFER];
-	const char     *string;
+	const char     *string = NULL;
 	char	       *lbracket, *rbracket, *content, *sep, *mods;
 	ssize_t		i;
 	ssize_t		begoff, endoff;
@@ -170,6 +170,8 @@ mda_expand_token(char *dest, size_t len, const char *token,
 		return -1;
 
 	if (string != tmp) {
+		if (string == NULL)
+			return -1;
 		if (strlcpy(tmp, string, sizeof tmp) >= sizeof tmp)
 			return -1;
 		string = tmp;

--- a/usr.sbin/smtpd/mda_variables.c
+++ b/usr.sbin/smtpd/mda_variables.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: mda_variables.c,v 1.8 2023/03/19 01:43:11 millert Exp $	*/
+/*	$OpenBSD: mda_variables.c,v 1.9 2023/03/19 16:43:44 millert Exp $	*/
 
 /*
  * Copyright (c) 2011-2017 Gilles Chehade <gilles@poolp.org>
@@ -254,7 +254,7 @@ mda_expand_format(char *buf, size_t len, const struct deliver *dlv,
 	char		exptok[EXPAND_BUFFER];
 	ssize_t		exptoklen;
 	char		token[MAXTOKENLEN];
-	size_t		ret, tmpret;
+	size_t		ret, tmpret, toklen;
 
 	if (len < sizeof tmpbuf) {
 		log_warnx("mda_expand_format: tmp buffer < rule buffer");
@@ -279,7 +279,6 @@ mda_expand_format(char *buf, size_t len, const struct deliver *dlv,
 		pbuf += 2;
 	}
 
-
 	/* expansion loop */
 	for (; *pbuf && ret < sizeof tmpbuf; ret += tmpret) {
 		if (*pbuf == '%' && *(pbuf + 1) == '%') {
@@ -296,17 +295,16 @@ mda_expand_format(char *buf, size_t len, const struct deliver *dlv,
 		}
 
 		/* %{...} otherwise fail */
-		if (*(pbuf+1) != '{' || (ebuf = strchr(pbuf+1, '}')) == NULL)
+		if ((ebuf = strchr(pbuf+2, '}')) == NULL)
 			return 0;
 
 		/* extract token from %{token} */
-		if ((size_t)(ebuf - pbuf) - 1 >= sizeof token)
+		toklen = ebuf - (pbuf+2);
+		if (toklen >= sizeof token)
 			return 0;
 
-		memcpy(token, pbuf+2, ebuf-pbuf-1);
-		if (strchr(token, '}') == NULL)
-			return 0;
-		*strchr(token, '}') = '\0';
+		memcpy(token, pbuf+2, toklen);
+		token[toklen] = '\0';
 
 		exptoklen = mda_expand_token(exptok, sizeof exptok, token, dlv,
 		    ui, mda_command);

--- a/usr.sbin/smtpd/mta_session.c
+++ b/usr.sbin/smtpd/mta_session.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: mta_session.c,v 1.146 2022/02/18 17:02:06 millert Exp $	*/
+/*	$OpenBSD: mta_session.c,v 1.147 2022/09/26 08:48:52 martijn Exp $	*/
 
 /*
  * Copyright (c) 2008 Pierre-Yves Ritschard <pyr@openbsd.org>

--- a/usr.sbin/smtpd/smtp_client.c
+++ b/usr.sbin/smtpd/smtp_client.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: smtp_client.c,v 1.16 2021/06/14 17:58:16 eric Exp $	*/
+/*	$OpenBSD: smtp_client.c,v 1.17 2022/12/28 21:30:18 jmc Exp $	*/
 
 /*
  * Copyright (c) 2018 Eric Faurot <eric@openbsd.org>
@@ -224,7 +224,7 @@ smtp_client_free(struct smtp_client *proto)
 }
 
 /*
- * End the session immediatly.
+ * End the session immediately.
  */
 static void
 smtp_client_abort(struct smtp_client *proto, int err, const char *reason)

--- a/usr.sbin/smtpd/smtp_session.c
+++ b/usr.sbin/smtpd/smtp_session.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: smtp_session.c,v 1.432 2021/07/01 07:42:16 eric Exp $	*/
+/*	$OpenBSD: smtp_session.c,v 1.433 2022/10/20 01:16:04 millert Exp $	*/
 
 /*
  * Copyright (c) 2008 Gilles Chehade <gilles@poolp.org>
@@ -2750,6 +2750,7 @@ static void
 smtp_message_begin(struct smtp_tx *tx)
 {
 	struct smtp_session *s;
+	struct smtp_rcpt *rcpt;
 	int	(*m_printf)(struct smtp_tx *, const char *, ...);
 
 	m_printf = smtp_message_printf;
@@ -2799,9 +2800,10 @@ smtp_message_begin(struct smtp_tx *tx)
 	}
 
 	if (tx->rcptcount == 1) {
+		rcpt = TAILQ_FIRST(&tx->rcpts);
 		m_printf(tx, "\n\tfor <%s@%s>",
-		    tx->evp.rcpt.user,
-		    tx->evp.rcpt.domain);
+		    rcpt->maddr.user,
+		    rcpt->maddr.domain);
 	}
 
 	m_printf(tx, ";\n\t%s\n", time_to_text(time(&tx->time)));

--- a/usr.sbin/smtpd/smtpctl.8
+++ b/usr.sbin/smtpd/smtpctl.8
@@ -1,4 +1,4 @@
-.\" $OpenBSD: smtpctl.8,v 1.65 2020/09/14 09:48:08 martijn Exp $
+.\" $OpenBSD: smtpctl.8,v 1.66 2023/03/02 17:09:53 jmc Exp $
 .\"
 .\" Copyright (c) 2006 Pierre-Yves Ritschard <pyr@openbsd.org>
 .\" Copyright (c) 2012 Gilles Chehade <gilles@poolp.org>
@@ -15,13 +15,13 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd $Mdocdate: September 14 2020 $
+.Dd $Mdocdate: March 2 2023 $
 .Dt SMTPCTL 8
 .Os
 .Sh NAME
 .Nm smtpctl ,
 .Nm mailq
-.Nd control the Simple Mail Transfer Protocol daemon
+.Nd control the SMTP daemon
 .Sh SYNOPSIS
 .Nm
 .Ar command

--- a/usr.sbin/smtpd/smtpd.8
+++ b/usr.sbin/smtpd/smtpd.8
@@ -1,4 +1,4 @@
-.\"	$OpenBSD: smtpd.8,v 1.32 2017/01/03 22:11:39 jmc Exp $
+.\"	$OpenBSD: smtpd.8,v 1.33 2023/03/02 17:09:53 jmc Exp $
 .\"
 .\" Copyright (c) 2012, Eric Faurot <eric@openbsd.org>
 .\" Copyright (c) 2008, Gilles Chehade <gilles@poolp.org>
@@ -16,12 +16,12 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd $Mdocdate: January 3 2017 $
+.Dd $Mdocdate: March 2 2023 $
 .Dt SMTPD 8
 .Os
 .Sh NAME
 .Nm smtpd
-.Nd Simple Mail Transfer Protocol daemon
+.Nd Simple Mail Transfer Protocol (SMTP) daemon
 .Sh SYNOPSIS
 .Nm
 .Op Fl dFhnv

--- a/usr.sbin/smtpd/smtpd.c
+++ b/usr.sbin/smtpd/smtpd.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: smtpd.c,v 1.343 2022/02/18 16:57:36 millert Exp $	*/
+/*	$OpenBSD: smtpd.c,v 1.344 2023/02/08 08:20:54 tb Exp $	*/
 
 /*
  * Copyright (c) 2008 Gilles Chehade <gilles@poolp.org>
@@ -353,7 +353,7 @@ parent_send_config_dispatcher(void)
 }
 
 void
-parent_send_config_lka()
+parent_send_config_lka(void)
 {
 	log_debug("debug: parent_send_config_ruleset: reloading");
 	m_compose(p_lka, IMSG_CONF_START, 0, 0, -1, NULL, 0);

--- a/usr.sbin/smtpd/smtpd.conf.5
+++ b/usr.sbin/smtpd/smtpd.conf.5
@@ -1,4 +1,4 @@
-.\"	$OpenBSD: smtpd.conf.5,v 1.263 2022/03/31 17:27:31 naddy Exp $
+.\"	$OpenBSD: smtpd.conf.5,v 1.264 2023/03/02 17:09:53 jmc Exp $
 .\"
 .\" Copyright (c) 2008 Janne Johansson <jj@openbsd.org>
 .\" Copyright (c) 2009 Jacek Masiulaniec <jacekm@dobremiasto.net>
@@ -17,12 +17,12 @@
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
 .\"
-.Dd $Mdocdate: March 31 2022 $
+.Dd $Mdocdate: March 2 2023 $
 .Dt SMTPD.CONF 5
 .Os
 .Sh NAME
 .Nm smtpd.conf
-.Nd Simple Mail Transfer Protocol daemon configuration file
+.Nd SMTP daemon configuration file
 .Sh DESCRIPTION
 .Nm
 is the configuration file for the mail daemon


### PR DESCRIPTION
This should bring OpenSMTPD-portable in pair with -CURRENT.  So far I've only build-tested it on OpenBSD and void linux (musl -- needed libbsd too) but as I was about to set up a new mx these days, i'll be able to test it more throughfully on linux soon.

A change from deraadt@ is still missing, but since it's tiny and allows to drop checks from the configure too I'll backport it in a separate PR once this lands: https://github.com/openbsd/src/commit/e16a722a8a965b85c7889b97d3d2e0580039ade0#diff-7e16a1fb5fcbd028a0757ac4fb5f020766f91e02fd50baf2fa5df6cc67ffb82e