### PR TITLE
drop sys/cdefs.h checks/includes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,7 +130,6 @@ AC_CHECK_HEADERS([ \
 	paths.h \
 	security/pam_appl.h \
 	shadow.h \
-	sys/cdefs.h \
 	sys/dir.h \
 	sys/file.h \
 	sys/mount.h \

--- a/openbsd-compat/fparseln.c
+++ b/openbsd-compat/fparseln.c
@@ -34,10 +34,6 @@
 
 #include "includes.h"
 
-#ifdef HAVE_SYS_CDEFS
-#include <sys/cdefs.h>
-#endif
-
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/usr.sbin/smtpd/log.h
+++ b/usr.sbin/smtpd/log.h
@@ -1,4 +1,4 @@
-/*	$OpenBSD: log.h,v 1.8 2018/04/26 20:57:59 eric Exp $	*/
+/*	$OpenBSD: log.h,v 1.9 2021/12/13 18:28:40 deraadt Exp $	*/
 
 /*
  * Copyright (c) 2003, 2004 Henning Brauer <henning@openbsd.org>
@@ -24,9 +24,6 @@
 #include <syslog.h>
 
 #include <stdarg.h>
-#ifdef HAVE_SYS_CDEFS_H
-#include <sys/cdefs.h>
-#endif
 
 void	log_init(int, int);
 void	log_procinit(const char *);


### PR DESCRIPTION
This is a backport of a commit from deraadt@ that we were missing, and also removing the now unused check for sys/cdefs.h.  I've also removed the include in fparseln.c, which were removed also by deraadt@ in 2012.