### PR TITLE
fix USER and LOGNAME in the env of the mda

### DIFF
--- a/usr.sbin/smtpd/mda_unpriv.c
+++ b/usr.sbin/smtpd/mda_unpriv.c
@@ -64,8 +64,8 @@ mda_unpriv(struct dispatcher *dsp, struct deliver *deliver,
 	xasprintf(&mda_environ[idx++], "RECIPIENT=%s@%s", deliver->dest.user, deliver->dest.domain);
 	xasprintf(&mda_environ[idx++], "SHELL=/bin/sh");
 	xasprintf(&mda_environ[idx++], "LOCAL=%s", deliver->rcpt.user);
-	xasprintf(&mda_environ[idx++], "LOGNAME=%s", pw_name);
-	xasprintf(&mda_environ[idx++], "USER=%s", pw_name);
+	xasprintf(&mda_environ[idx++], "LOGNAME=%s", deliver->userinfo.username);
+	xasprintf(&mda_environ[idx++], "USER=%s", deliver->userinfo.username);
 
 	if (deliver->sender.user[0])
 		xasprintf(&mda_environ[idx++], "SENDER=%s@%s",


### PR DESCRIPTION
spotted while looking at the diff with CVS, it was changed by crisz@ in rev. 1.7 with

> Run lmtp deliveries as SMTPD_USER instead of the recipient user.

which was ported, since the other part of that commit (parse.y bits) are in-tree.  I couldn't find in the history when this was exactly backported, sorry!

@poolpOrg just to be sure, can you please take a look?