### PR TITLE
libtls: unbreak with OpenSSL 3.x

### DIFF
--- a/openbsd-compat/libtls/tls.c
+++ b/openbsd-compat/libtls/tls.c
@@ -399,7 +399,8 @@ tls_keypair_setup_pkey(struct tls *ctx, struct tls_keypair *keypair, EVP_PKEY *p
 	switch (EVP_PKEY_id(pkey)) {
 	case EVP_PKEY_RSA:
 		if ((rsa = EVP_PKEY_get1_RSA(pkey)) == NULL ||
-		    RSA_set_ex_data(rsa, 0, keypair->pubkey_hash) == 0) {
+		    RSA_set_ex_data(rsa, 0, keypair->pubkey_hash) == 0 ||
+		    EVP_PKEY_set1_RSA(pkey, rsa) == 0) {
 			tls_set_errorx(ctx, "RSA key setup failure");
 			goto err;
 		}
@@ -407,13 +408,15 @@ tls_keypair_setup_pkey(struct tls *ctx, struct tls_keypair *keypair, EVP_PKEY *p
 	case EVP_PKEY_EC:
 #if defined(SUPPORT_ECDSA)
 		if ((eckey = EVP_PKEY_get1_EC_KEY(pkey)) == NULL ||
-		    ECDSA_set_ex_data(eckey, 0, keypair->pubkey_hash) == 0) {
+		    ECDSA_set_ex_data(eckey, 0, keypair->pubkey_hash) == 0 ||
+		    EVP_PKEY_set1_EC_KEY(pkey, eckey) == 0) {
 			tls_set_errorx(ctx, "EC key setup failure");
 			goto err;
 		}
 #else
 		if ((eckey = EVP_PKEY_get1_EC_KEY(pkey)) == NULL ||
-		    EC_KEY_set_ex_data(eckey, 0, keypair->pubkey_hash) == 0) {
+		    EC_KEY_set_ex_data(eckey, 0, keypair->pubkey_hash) == 0 ||
+		    EVP_PKEY_set1_EC_KEY(pkey, eckey) == 0) {
 			tls_set_errorx(ctx, "EC key setup failure");
 			goto err;
 		}


### PR DESCRIPTION
In OpenSSL 3.x due to a behaviour change EVP_PKEY_get1_EC_KEY() returns a cashed copy of the provider's key, so subsequent updates are not reflected back breaking the privsep usage and making the handshake fail with a cryptic "missing private key".  Instead, we have to set the changed key explicitly.

See #1171