### PR TITLE
Add GH Runner to build images of release tags

### DIFF
--- a/.github/workflows/alpine-release.yml
+++ b/.github/workflows/alpine-release.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - v*
+env:
+  IMAGE_NAME: ${{ github.repository }}
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/alpine-release.yml
+++ b/.github/workflows/alpine-release.yml
@@ -2,7 +2,6 @@ name: Alpine Linux release
 on: 
   push:
     tags:
-      - *
 env:
   IMAGE_NAME: "opensmtpd"
 jobs:

--- a/.github/workflows/alpine-release.yml
+++ b/.github/workflows/alpine-release.yml
@@ -4,14 +4,14 @@ on:
     tags:
       - v*
 env:
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: "opensmtpd"
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Alpine Linux (amd64 musl openssl)
-      run: docker build . --file ci/docker/Dockerfile.alpine --tag opensmtpd:alpine
+      run: docker build . --file ci/docker/Dockerfile.alpine-release --tag opensmtpd:alpine
 
     - name: Login to ghcr.io
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin

--- a/.github/workflows/alpine-release.yml
+++ b/.github/workflows/alpine-release.yml
@@ -11,11 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Alpine Linux (amd64 musl openssl)
+
+    - name: Build the Dockerfile
       run: docker build . --file ci/docker/Dockerfile.alpine-release --tag opensmtpd:alpine
 
     - name: Login to ghcr.io
-      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    #   run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+    
 
     - name: Push Image
       run: |

--- a/.github/workflows/alpine-release.yml
+++ b/.github/workflows/alpine-release.yml
@@ -7,6 +7,7 @@ env:
   IMAGE_NAME: "opensmtpd"
 jobs:
   build:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/alpine-release.yml
+++ b/.github/workflows/alpine-release.yml
@@ -1,0 +1,32 @@
+name: Alpine Linux (amd64 musl openssl)
+on: 
+  push:
+    tags:
+      - v*
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Alpine Linux (amd64 musl openssl)
+      run: docker build . --file ci/docker/Dockerfile.alpine --tag opensmtpd:alpine
+
+    - name: Login to ghcr.io
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
+    - name: Push Image
+      run: |
+        IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+        # Change all uppercase to lowercase
+        IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+        # Strip git ref prefix from version
+        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+        # Strip "v" prefix from tag name
+        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+        # Use Docker `latest` tag convention
+        [ "$VERSION" == "master" ] && VERSION=latest
+        echo IMAGE_ID=$IMAGE_ID
+        echo VERSION=$VERSION
+        docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+        docker push $IMAGE_ID:$VERSION
+

--- a/.github/workflows/alpine-release.yml
+++ b/.github/workflows/alpine-release.yml
@@ -26,9 +26,8 @@ jobs:
         # Strip "v" prefix from tag name
         [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
         # Use Docker `latest` tag convention
-        [ "$VERSION" == "master" ] && VERSION=latest
         echo IMAGE_ID=$IMAGE_ID
         echo VERSION=$VERSION
-        docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+        docker tag $IMAGE_NAME:alpine $IMAGE_ID:$VERSION
         docker push $IMAGE_ID:$VERSION
 

--- a/.github/workflows/alpine-release.yml
+++ b/.github/workflows/alpine-release.yml
@@ -1,4 +1,4 @@
-name: Alpine Linux (amd64 musl openssl)
+name: Alpine Linux release
 on: 
   push:
     tags:

--- a/.github/workflows/alpine-release.yml
+++ b/.github/workflows/alpine-release.yml
@@ -2,7 +2,7 @@ name: Alpine Linux release
 on: 
   push:
     tags:
-      - v*
+      - *
 env:
   IMAGE_NAME: "opensmtpd"
 jobs:
@@ -32,10 +32,9 @@ jobs:
         # Strip git ref prefix from version
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
         # Strip "v" prefix from tag name
-        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-        # Use Docker `latest` tag convention
+        # [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
         echo IMAGE_ID=$IMAGE_ID
         echo VERSION=$VERSION
-        docker tag $IMAGE_NAME:alpine $IMAGE_ID:$VERSION
+        docker tag opensmtpd:alpine $IMAGE_ID:$VERSION
         docker push $IMAGE_ID:$VERSION
 

--- a/ci/docker/Dockerfile.alpine-release
+++ b/ci/docker/Dockerfile.alpine-release
@@ -55,10 +55,13 @@ RUN apk add --no-cache libevent \
     linux-pam \
     fts
 
-COPY --from=build /usr/local /usr/local/
-COPY --from=build /etc/mail/smtpd.conf /etc/mail/
+# Trailing slashes are important!
+COPY --from=build /usr/local/libexec/opensmtpd /usr/local/libexec/
+COPY --from=build /usr/local/sbin/smtpctl /usr/local/sbin/
+COPY --from=build /usr/local/sbin/smtpd /usr/local/sbin/
+COPY --from=build /usr/local/bin/smtp /usr/local/bin/
 
-# && cp etc/aliases /etc/mail/aliases
+COPY --from=build /etc/mail/smtpd.conf /etc/mail/
 
 COPY --from=build /opensmtpd/etc/aliases /etc/mail/aliases
 

--- a/ci/docker/Dockerfile.alpine-release
+++ b/ci/docker/Dockerfile.alpine-release
@@ -48,4 +48,4 @@ RUN ./bootstrap \
   && make install \
   && cp etc/aliases /etc/mail/aliases
 
-ENTRYPOINT ["smtpd"]
+ENTRYPOINT ["smtpd", "-d"]

--- a/ci/docker/Dockerfile.alpine-release
+++ b/ci/docker/Dockerfile.alpine-release
@@ -1,10 +1,7 @@
 FROM alpine:3.15 as build
 
-# creates /opensmtpd dir and makes all following commands to run in it
-# https://docs.docker.com/engine/reference/builder/#workdir
 WORKDIR /opensmtpd
 
-# install necessary packages
 RUN apk add --no-cache \
     autoconf \
     automake \
@@ -22,9 +19,6 @@ RUN apk add --no-cache \
     openssl-dev \
     zlib-dev
 
-# create users and directories
-# note: alpine uses busybox and useradd is not available there
-# also long flags are not available too, so sorry for the
 RUN mkdir -p /var/lib/opensmtpd/empty \
   && adduser _smtpd -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false \
   && adduser _smtpq -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false \
@@ -33,11 +27,9 @@ RUN mkdir -p /var/lib/opensmtpd/empty \
   && mkdir -p /etc/mail \
   && chmod 711 /var/spool/smtpd \
   && mkdir ./install
-# Copy contentes of the repo inside the container
-# https://docs.docker.com/engine/reference/builder/#copy
+
 COPY . /opensmtpd
 
-# build opensmtpd
 RUN ./bootstrap \
   && ./configure \
        --with-gnu-ld \
@@ -45,6 +37,8 @@ RUN ./bootstrap \
        --with-auth-pam \
   && make \
   && make install
+
+# --- BEGIN Production deployment dockerfile --- #
 
 FROM alpine:3.15 AS deploy
 

--- a/ci/docker/Dockerfile.alpine-release
+++ b/ci/docker/Dockerfile.alpine-release
@@ -1,0 +1,51 @@
+FROM alpine:3.15 as build
+
+# creates /opensmtpd dir and makes all following commands to run in it
+# https://docs.docker.com/engine/reference/builder/#workdir
+WORKDIR /opensmtpd
+
+# install necessary packages
+RUN apk add --no-cache \
+    autoconf \
+    automake \
+    bison \
+    ca-certificates \
+    fts-dev \
+    gcc \
+    fts \
+    libevent-dev \
+    libtool \
+    libtool \
+    linux-pam-dev \
+    make \
+    musl-dev \
+    openssl \
+    openssl-dev \
+    zlib-dev
+
+# create users and directories
+# note: alpine uses busybox and useradd is not available there
+# also long flags are not available too, so sorry for the
+RUN mkdir -p /var/lib/opensmtpd/empty \
+  && adduser _smtpd -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false \
+  && adduser _smtpq -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false \
+  && mkdir -p /var/spool/smtpd \
+  && mkdir -p /var/mail \
+  && mkdir -p /etc/mail \
+  && chmod 711 /var/spool/smtpd
+
+# Copy contentes of the repo inside the container
+# https://docs.docker.com/engine/reference/builder/#copy
+COPY . /opensmtpd
+
+# build opensmtpd
+RUN ./bootstrap \
+  && ./configure \
+       --with-gnu-ld \
+       --sysconfdir=/etc/mail \
+       --with-auth-pam \
+  && make \
+  && make install \
+  && cp etc/aliases /etc/mail/aliases
+
+ENTRYPOINT ["smtpd"]

--- a/ci/docker/Dockerfile.alpine-release
+++ b/ci/docker/Dockerfile.alpine-release
@@ -15,7 +15,6 @@ RUN apk add --no-cache \
     fts \
     libevent-dev \
     libtool \
-    libtool \
     linux-pam-dev \
     make \
     musl-dev \
@@ -32,8 +31,8 @@ RUN mkdir -p /var/lib/opensmtpd/empty \
   && mkdir -p /var/spool/smtpd \
   && mkdir -p /var/mail \
   && mkdir -p /etc/mail \
-  && chmod 711 /var/spool/smtpd
-
+  && chmod 711 /var/spool/smtpd \
+  && mkdir ./install
 # Copy contentes of the repo inside the container
 # https://docs.docker.com/engine/reference/builder/#copy
 COPY . /opensmtpd
@@ -45,7 +44,28 @@ RUN ./bootstrap \
        --sysconfdir=/etc/mail \
        --with-auth-pam \
   && make \
-  && make install \
-  && cp etc/aliases /etc/mail/aliases
+  && make install
+
+FROM alpine:3.15 AS deploy
+
+RUN mkdir -p /var/lib/opensmtpd/empty \
+  && adduser _smtpd -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false \
+  && adduser _smtpq -h /var/lib/opensmtpd/empty/ -D -H -s /bin/false \
+  && mkdir -p /var/spool/smtpd \
+  && mkdir -p /var/mail \
+  && mkdir -p /etc/mail \
+  && chmod 711 /var/spool/smtpd
+
+RUN apk add --no-cache libevent \
+    openssl \
+    linux-pam \
+    fts
+
+COPY --from=build /usr/local /usr/local/
+COPY --from=build /etc/mail/smtpd.conf /etc/mail/
+
+# && cp etc/aliases /etc/mail/aliases
+
+COPY --from=build /opensmtpd/etc/aliases /etc/mail/aliases
 
 ENTRYPOINT ["smtpd", "-d"]


### PR DESCRIPTION
Hello OpenSMTPD team,

I noticed that there were no "official" "source of truth" docker/container images for OpenSMTPD. I would like to propose and help have "official" opensmtpd containers on Github's container registry `ghcr.io/opensmtd/<image>`. 

Currently, I have adapted the `ci` dockerfile for alpine to add the entrypoint, and added the GH runner yaml to parse the tag number and apply it as a tag on the image (taken from github's documentation).

I assume extensive testing will be required (which I haven't gotten around to), opening this PR to open discussion.