### PR TITLE
Nullmx

### DIFF
--- a/usr.sbin/smtpd/mta.c
+++ b/usr.sbin/smtpd/mta.c
@@ -1105,6 +1105,10 @@ mta_on_mx(void *tag, void *arg, void *data)
 		else
 			relay->failstr = "No MX found for domain";
 		break;
+	case DNS_NULLMX:
+		relay->fail = IMSG_MTA_DELIVERY_PERMFAIL;
+		relay->failstr = "Domain does not accept mail";
+		break;
 	default:
 		fatalx("bad DNS lookup error code");
 		break;

--- a/usr.sbin/smtpd/smtpd.h
+++ b/usr.sbin/smtpd/smtpd.h
@@ -1050,6 +1050,8 @@ enum dns_error {
 	DNS_EINVAL,
 	DNS_ENONAME,
 	DNS_ENOTFOUND,
+	/* rfc 7505 */
+	DNS_NULLMX,
 };
 
 enum lka_resp_status {


### PR DESCRIPTION
This implement null mx (rfc 7505). Also filter `localhost` mx entries and handles only `localhost` mx entries as null mx (see #1190).

Sorry I have currently not the time to test this, maybe someone else can test it.