### PR TITLE
make documentation more explicit about the auth label

### DIFF
--- a/usr.sbin/smtpd/table.5
+++ b/usr.sbin/smtpd/table.5
@@ -153,7 +153,11 @@ label1	user:password
 .Ed
 .Pp
 The label must be unique and is used as a selector for the proper credentials
-when multiple credentials are valid for a single destination.
+when multiple credentials are valid for a single destination. This means, that
+the relay must with this example be specified like:
+.Bd -unfilled -offset indent
+.Ic action Ar name Cm relay host Ar smtp+tls://label1@example.org Cm auth Pf < Ar table Ns >
+.Ed
 The password is not encrypted as it must be provided to the remote host.
 .Ss Netaddr tables
 Netaddr tables are lists of IPv4 and IPv6 network addresses.


### PR DESCRIPTION
Hey! I just spent a bit more than 4 hours (based on my DNS delayed) trying to understand why I couldn't relay email through an external authed server, before figuring out that I actually just missed adding the auth label.

Here is a suggested change to docs which should hopefully make it more explicit, as I had been reading docs first thing and I was wondering what that "label1" was about. I probably should have checked the documentation of `host` again, but as my setup without-auth did work fine I didn't think of it.

Also, it might make sense to error out when parsing a relay line has an `auth` table defined but no label, maybe, as it'd be ill-formed? Though TBH there may already have been a warning that I missed, as I thought it was a problem of networking between my node and the other node and spent most of my time debugging in that direction.