### PR TITLE
Add container image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ OpenSMTPD is available from [MacPorts](https://www.macports.org):
 
     port install opensmtpd
 
+## Install via container
+
+Container images available at [this repo's packages page.](https://github.com/orgs/OpenSMTPD/packages)
+
 ## Install from source
 
 ### Install dependencies


### PR DESCRIPTION
Now that the CI for generating container images and publishing on GHCR is up, we can add this to the README for greater visibility.

