### PR TITLE
work around arc4random() symbol clash with old LibreSSL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,8 +99,9 @@ AS_CASE(["$host"],
 ])
 AC_SUBST([pkglibexecdir])
 
+# XXX arc4random is checked later since some old (pre 3.8) versions of
+# LibreSSL provide this symbols mistakenly.
 AC_REPLACE_FUNCS([ \
-	arc4random \
 	basename \
 	clock_gettime \
 	closefrom \
@@ -1317,6 +1318,10 @@ AC_SEARCH_LIBS([RAND_add], [crypto], [:], [
 AC_SEARCH_LIBS([SSL_CTX_new], [ssl], [:], [
 	AC_MSG_ERROR([can't find libssl])
 ])
+
+# Check arc4random only after libcrypto to avoid issues with old
+# (pre 3.8) versions of LibreSSL.
+AC_REPLACE_FUNCS([arc4random])
 
 AC_CHECK_FUNCS([ \
 	SSL_CTX_use_certificate_chain_mem \

--- a/openbsd-compat/includes.h
+++ b/openbsd-compat/includes.h
@@ -18,6 +18,8 @@
 
 #include "config.h"
 
+#include <openssl/opensslv.h>
+
 #include <sys/types.h>
 #include <sys/socket.h> /* For CMSG_* */
 

--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -121,6 +121,10 @@ int BSDgetopt(int argc, char * const *argv, const char *opts);
 int getpeereid(int , uid_t *, gid_t *);
 #endif
 
+/*
+ * XXX some old versions of LibreSSL (pre 3.8) provide 
+ * arc4random(), work around that.
+ */
 #if !defined(HAVE_ARC4RANDOM) || defined(LIBRESSL_VERSION_NUMBER)
 unsigned int arc4random(void);
 #endif


### PR DESCRIPTION
LibreSSL pre 3.8 leaks the symbols of their compats in libcrypto. This is particularly painful with arc4random() which, in our implementation, relies on libcrypto.  LibreSSL' RAND_add() calls itself arc4random_buf() resulting in an infinite loop due to the symbol clash.

Instead, check for arc4random() only after we've found libcrypto, and re-establish the prototype hack in openbsd-compat.h.  Hopefully we'll be able to get rid of this workaround in a few releases.

Issue reported by @graywolf, thank you!

Fixes #1233