### PR TITLE
fix res_hnok and b64_{pton,ntop} on macos

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -255,7 +255,14 @@ AC_SEARCH_LIBS([pidfile], [util],
 
 AC_SEARCH_LIBS([res_hnok], [resolv],
 	[AC_DEFINE([HAVE_RES_HNOK], 1, [1 if have res_hnok])],
-	[AC_LIBOBJ([res_hnok])])
+	[
+		dnl darwin (at least) has res_9_hnok plus #defines
+		dnl to "rename" it to res_hnok.
+		AC_SEARCH_LIBS([res_9_hnok], [resolv], [
+			AC_DEFINE([HAVE_RES_HNOK], 1, [1 if have res_hnok])
+			AC_LIBOBJ([res_hnok])
+		])
+	])
 
 AC_SEARCH_LIBS([res_randomid], [resolv],
 	[AC_DEFINE([HAVE_RES_RANDOMID], 1, [1 if have res_randomid])],
@@ -263,7 +270,6 @@ AC_SEARCH_LIBS([res_randomid], [resolv],
 
 AC_SEARCH_LIBS([setsockopt], [socket], [:],
 	[AC_MSG_ERROR([can't find setsockopt])])
-
 
 AC_SEARCH_LIBS([__b64_pton], [resolv],
 	[AC_DEFINE([HAVE___B64_PTON], 1, [1 if have __b64_pton])])
@@ -274,8 +280,16 @@ AC_SEARCH_LIBS([__b64_ntop], [resolv],
 AC_SEARCH_LIBS([b64_ntop], [resolv],
 	[AC_DEFINE([HAVE_b64_NTOP], 1, [1 if have b64_ntop])])
 
+dnl darwin (at least) has these plus #defines in resolv.h
+AC_SEARCH_LIBS([res_9_b64_pton], [resolv],
+	[AC_DEFINE([HAVE_RES_9_B64_PTON], 1, [1 if have res_9_b64_pton])])
+AC_SEARCH_LIBS([res_9_b64_ntop], [resolv],
+	[AC_DEFINE([HAVE_RES_9_B64_NTOP], 1, [1 if have res_9_b64_ntop])])
+
 AS_IF([test "x$ac_cv_search_b64_ntop" = "xno" -a \
-    "x$ac_cv_search___b64_ntop" = "xno"], [
+    "x$ac_cv_search___b64_ntop" = "xno" -a \
+    "x$ac_cv_search_res_9_b64_pton" = "xno" -a \
+    "x$ac_cv_search_res_9_b64_ntop" = "xno"], [
 	AC_LIBOBJ([base64])
 ])
 


### PR DESCRIPTION
since ebea68918a we're not "aggressively" depending on libresolv and this caused breakage on macos since the build there relied on the configure script adding -lresolv if found even if apparently not needed.

Now it fails to build since we include resolv.h which has #defines from res_hnok (and b64_{pton,ntop}) to the res_9_* "namespace", and not linking with -lresolve leaves those symbols undefined.

So, check additionally for the res_9_* function names to pull in -lresolv on macos.

Issue reported by @artkiver (グレェ), github issue #1232, thanks!