### PR TITLE
add compat glue for EAI_OVERFLOW too

### DIFF
--- a/openbsd-compat/defines.h
+++ b/openbsd-compat/defines.h
@@ -457,6 +457,10 @@ typedef uint16_t	in_port_t;
 #endif
 /* end of chl */
 
+#ifndef EAI_OVERFLOW
+#define EAI_OVERFLOW EAI_FAIL
+#endif
+
 #ifndef HAVE_FPARSELN
 /*
  * fparseln() specific operation flags.


### PR DESCRIPTION
it's not always available on some old darwin versions, so apply a similar treatment that `EAI_NODATA` gets: re-define it as `EAI_FAIL`.

See issue #1246