### PR TITLE
fix: clamp HOST_NAME_MAX

### DIFF
--- a/openbsd-compat/defines.h
+++ b/openbsd-compat/defines.h
@@ -38,6 +38,11 @@
 # endif
 #endif
 
+#if defined(HOST_NAME_MAX) && defined(_POSIX_HOST_NAME_MAX) && HOST_NAME_MAX < _POSIX_HOST_NAME_MAX
+# undef HOST_NAME_MAX
+# define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#endif
+
 #ifndef PATH_MAX
 # ifdef _POSIX_PATH_MAX
 # define PATH_MAX _POSIX_PATH_MAX


### PR DESCRIPTION
Debian based systems have an HOST_NAME_MAX lower than _POSIX_HOST_NAME_MAX and it causes the issue #1252 Clamp HOST_NAME_MAX in the sysconf way: https://manpages.ubuntu.com/manpages/trusty/fr/man3/sysconf.3.html