### PR TITLE
fix: clamp HOST_NAME_MAX

### DIFF
--- a/openbsd-compat/defines.h
+++ b/openbsd-compat/defines.h
@@ -32,9 +32,17 @@
 #define INFTIM	(-1)
 #endif
 
-#ifndef HOST_NAME_MAX
-# ifdef _POSIX_HOST_NAME_MAX
-# define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#ifndef SMTPD_HOST_NAME_MAX
+# ifdef HOST_NAME_MAX
+#  if defined(_POSIX_HOST_NAME_MAX) && HOST_NAME_MAX < _POSIX_HOST_NAME_MAX
+#   define SMTPD_HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#  else
+#   define SMTPD_HOST_NAME_MAX HOST_NAME_MAX
+#  endif
+# elif defined(_POSIX_HOST_NAME_MAX)
+#  define SMTPD_HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+# else
+#  define SMTPD_HOST_NAME_MAX 255
 # endif
 #endif
 

--- a/usr.sbin/smtpd/config.c
+++ b/usr.sbin/smtpd/config.c
@@ -42,7 +42,7 @@ config_default(void)
 	struct smtpd	       *conf = NULL;
 	struct mta_limits      *limits = NULL;
 	struct table	       *t = NULL;
-	char			hostname[HOST_NAME_MAX+1];
+	char			hostname[SMTPD_HOST_NAME_MAX+1];
 
 	if (getmailname(hostname, sizeof hostname) == -1)
 		return NULL;

--- a/usr.sbin/smtpd/dns.c
+++ b/usr.sbin/smtpd/dns.c
@@ -54,7 +54,7 @@ struct dns_session {
 	struct mproc		*p;
 	uint64_t		 reqid;
 	int			 type;
-	char			 name[HOST_NAME_MAX+1];
+	char			 name[SMTPD_HOST_NAME_MAX+1];
 	size_t			 mxfound;
 	int			 error;
 	int			 refcount;
@@ -356,7 +356,7 @@ dns_lookup_host(struct dns_session *s, const char *host, int preference)
 {
 	struct dns_lookup	*lookup;
 	struct addrinfo		 hints;
-	char			 hostcopy[HOST_NAME_MAX+1];
+	char			 hostcopy[SMTPD_HOST_NAME_MAX+1];
 	char			*p;
 	void			*as;
 

--- a/usr.sbin/smtpd/enqueue.c
+++ b/usr.sbin/smtpd/enqueue.c
@@ -96,7 +96,7 @@ struct {
 #define WSP(c)			(c == ' ' || c == '\t')
 
 int		 verbose = 0;
-static char	 host[HOST_NAME_MAX+1];
+static char	 host[SMTPD_HOST_NAME_MAX+1];
 char		*user = NULL;
 time_t		 timestamp;
 

--- a/usr.sbin/smtpd/mail.maildir.c
+++ b/usr.sbin/smtpd/mail.maildir.c
@@ -118,7 +118,7 @@ maildir_engine(const char *dirname, int junk)
 	char	extpath[PATH_MAX];
 	char	subdir[PATH_MAX];
 	char	filename[PATH_MAX];
-	char	hostname[HOST_NAME_MAX+1];
+	char	hostname[SMTPD_HOST_NAME_MAX+1];
 
 	char	tmp[PATH_MAX];
 	char	new[PATH_MAX];

--- a/usr.sbin/smtpd/mta.c
+++ b/usr.sbin/smtpd/mta.c
@@ -173,7 +173,7 @@ static time_t	max_seen_discdelay_route;
 
 #define	HOSTSTAT_EXPIRE_DELAY	(4 * 3600)
 struct hoststat {
-	char			 name[HOST_NAME_MAX+1];
+	char			 name[SMTPD_HOST_NAME_MAX+1];
 	time_t			 tm;
 	char			 error[LINE_MAX];
 	struct tree		 deferred;
@@ -2644,7 +2644,7 @@ void
 mta_hoststat_update(const char *host, const char *error)
 {
 	struct hoststat	*hs = NULL;
-	char		 buf[HOST_NAME_MAX+1];
+	char		 buf[SMTPD_HOST_NAME_MAX+1];
 
 	if (!lowercase(buf, host, sizeof buf))
 		return;
@@ -2669,7 +2669,7 @@ void
 mta_hoststat_cache(const char *host, uint64_t evpid)
 {
 	struct hoststat	*hs = NULL;
-	char buf[HOST_NAME_MAX+1];
+	char buf[SMTPD_HOST_NAME_MAX+1];
 
 	if (!lowercase(buf, host, sizeof buf))
 		return;
@@ -2688,7 +2688,7 @@ void
 mta_hoststat_uncache(const char *host, uint64_t evpid)
 {
 	struct hoststat	*hs = NULL;
-	char buf[HOST_NAME_MAX+1];
+	char buf[SMTPD_HOST_NAME_MAX+1];
 
 	if (!lowercase(buf, host, sizeof buf))
 		return;
@@ -2704,7 +2704,7 @@ void
 mta_hoststat_reschedule(const char *host)
 {
 	struct hoststat	*hs = NULL;
-	char		 buf[HOST_NAME_MAX+1];
+	char		 buf[SMTPD_HOST_NAME_MAX+1];
 	uint64_t	 evpid;
 
 	if (!lowercase(buf, host, sizeof buf))

--- a/usr.sbin/smtpd/parse.y
+++ b/usr.sbin/smtpd/parse.y
@@ -332,7 +332,7 @@ ADMD STRING {
 
 ca:
 CA STRING {
-	char buf[HOST_NAME_MAX+1];
+	char buf[SMTPD_HOST_NAME_MAX+1];
 
 	/* if not catchall, check that it is a valid domain */
 	if (strcmp($2, "*") != 0) {
@@ -401,7 +401,7 @@ MTA MAX_DEFERRED NUMBER  {
 
 pki:
 PKI STRING {
-	char buf[HOST_NAME_MAX+1];
+	char buf[SMTPD_HOST_NAME_MAX+1];
 
 	/* if not catchall, check that it is a valid domain */
 	if (strcmp($2, "*") != 0) {

--- a/usr.sbin/smtpd/smtp_session.c
+++ b/usr.sbin/smtpd/smtp_session.c
@@ -138,8 +138,8 @@ struct smtp_session {
 	struct listener		*listener;
 	void			*ssl_ctx;
 	struct sockaddr_storage	 ss;
-	char			 rdns[HOST_NAME_MAX+1];
-	char			 smtpname[HOST_NAME_MAX+1];
+	char			 rdns[SMTPD_HOST_NAME_MAX+1];
+	char			 smtpname[SMTPD_HOST_NAME_MAX+1];
 	int			 fcrdns;
 
 	int			 flags;

--- a/usr.sbin/smtpd/smtpd.h
+++ b/usr.sbin/smtpd/smtpd.h
@@ -142,7 +142,7 @@ struct netaddr {
 struct relayhost {
 	uint16_t flags;
 	int tls;
-	char hostname[HOST_NAME_MAX+1];
+	char hostname[SMTPD_HOST_NAME_MAX+1];
 	uint16_t port;
 	char authlabel[PATH_MAX];
 };
@@ -153,7 +153,7 @@ struct credentials {
 };
 
 struct destination {
-	char	name[HOST_NAME_MAX+1];
+	char	name[SMTPD_HOST_NAME_MAX+1];
 };
 
 struct source {
@@ -162,7 +162,7 @@ struct source {
 
 struct addrname {
 	struct sockaddr_storage	addr;
-	char			name[HOST_NAME_MAX+1];
+	char			name[SMTPD_HOST_NAME_MAX+1];
 };
 
 union lookup {
@@ -497,7 +497,7 @@ struct maddrmap {
 struct envelope {
 	TAILQ_ENTRY(envelope)		entry;
 
-	char				dispatcher[HOST_NAME_MAX+1];
+	char				dispatcher[SMTPD_HOST_NAME_MAX+1];
 
 	char				tag[SMTPD_TAG_SIZE];
 
@@ -505,9 +505,9 @@ struct envelope {
 	uint64_t			id;
 	enum envelope_flags		flags;
 
-	char				smtpname[HOST_NAME_MAX+1];
-	char				helo[HOST_NAME_MAX+1];
-	char				hostname[HOST_NAME_MAX+1];
+	char				smtpname[SMTPD_HOST_NAME_MAX+1];
+	char				helo[SMTPD_HOST_NAME_MAX+1];
+	char				hostname[SMTPD_HOST_NAME_MAX+1];
 	char				username[SMTPD_MAXMAILADDRSIZE];
 	char				errorline[LINE_MAX];
 	struct sockaddr_storage		ss;
@@ -553,7 +553,7 @@ struct listener {
 	char			 ca_name[PATH_MAX];
 	char			 tag[SMTPD_TAG_SIZE];
 	char			 authtable[LINE_MAX];
-	char			 hostname[HOST_NAME_MAX+1];
+	char			 hostname[SMTPD_HOST_NAME_MAX+1];
 	char			 hostnametable[PATH_MAX];
 	char			 sendertable[PATH_MAX];
 
@@ -615,7 +615,7 @@ struct smtpd {
 	int				sc_ttl;
 #define MAX_BOUNCE_WARN			4
 	time_t				sc_bounce_warn[MAX_BOUNCE_WARN];
-	char				sc_hostname[HOST_NAME_MAX+1];
+	char				sc_hostname[SMTPD_HOST_NAME_MAX+1];
 	struct stat_backend	       *sc_stat;
 	struct compress_backend	       *sc_comp;
 

--- a/usr.sbin/smtpd/ssl.h
+++ b/usr.sbin/smtpd/ssl.h
@@ -16,7 +16,7 @@
  */
 
 struct pki {
-	char			 pki_name[HOST_NAME_MAX+1];
+	char			 pki_name[SMTPD_HOST_NAME_MAX+1];
 
 	char			*pki_cert_file;
 	char			*pki_cert;
@@ -30,7 +30,7 @@ struct pki {
 };
 
 struct ca {
-	char			 ca_name[HOST_NAME_MAX+1];
+	char			 ca_name[SMTPD_HOST_NAME_MAX+1];
 
 	char			*ca_cert_file;
 	char			*ca_cert;


### PR DESCRIPTION
Debian based systems have an HOST_NAME_MAX lower than _POSIX_HOST_NAME_MAX and it causes the issue #1252
It is usually clamped by sysconf: https://manpages.ubuntu.com/manpages/trusty/fr/man3/sysconf.3.html
Using a new SMTPD_HOST_NAME_MAX define to hold the correct value without redefining HOST_NAME_MAX

NB: This follows up another PR that I deleted by mistake: https://github.com/OpenSMTPD/OpenSMTPD/pull/1254