### PR TITLE
Move compat/libtls inclusion in the Makefile.am

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,13 +40,6 @@ AC_PATH_PROG([CHOWN], [chown])
 AC_PATH_PROG([ZCAT], [zcat])
 AC_PATH_PROG([SED], [sed])
 
-AM_CFLAGS="-I\${top_srcdir}/openbsd-compat"
-
-dnl XXX: OpenSMTPD and libtls need to stay in sync, otherwise bad
-dnl things can happen at runtime.  Revisit this in the future once we
-dnl switch to the signer APIs.
-AM_CFLAGS="${AM_CFLAGS} -I\${top_srcdir}/openbsd-compat/libtls"
-
 # use libbsd by default; these needs to precede any other check, as we
 # might not need a compat function when using libbsd.
 AC_ARG_WITH([libbsd],

--- a/contrib/libexec/encrypt/Makefile.am
+++ b/contrib/libexec/encrypt/Makefile.am
@@ -3,6 +3,8 @@ pkglibexec_PROGRAMS = encrypt
 encrypt_SOURCES	= encrypt.c
 encrypt_SOURCES	+= $(top_srcdir)/usr.sbin/smtpd/log.c
 
+AM_CPPFLAGS =	-I$(top_srcdir)/openbsd-compat/
+
 LDADD =  $(LIBOBJS)
 
 uninstall-hook:

--- a/contrib/libexec/lockspool/Makefile.am
+++ b/contrib/libexec/lockspool/Makefile.am
@@ -8,7 +8,7 @@ dist_man1_MANS =	lockspool.1
 
 EXTRA_DIST =		mail.local.h pathnames.h
 
-AM_CPPFLAGS = 		-I$(top_srcdir)/mail.local
+AM_CPPFLAGS =		-I$(top_srcdir)/openbsd-compat/
 
 LDADD = 		$(LIBOBJS)
 

--- a/contrib/libexec/mail.local/Makefile.am
+++ b/contrib/libexec/mail.local/Makefile.am
@@ -8,7 +8,8 @@ dist_man8_MANS = mail.local.8
 
 EXTRA_DIST =		mail.local.h pathnames.h
 
-AM_CPPFLAGS = 		-DPATH_LIBEXEC=\"$(pkglibexecdir)\"
+AM_CPPFLAGS =		-I$(top_srcdir)/openbsd-compat/ \
+			-DPATH_LIBEXEC=\"$(pkglibexecdir)\"
 
 LDADD = 		$(LIBOBJS)
 

--- a/mk/mail/mail.lmtp/Makefile.am
+++ b/mk/mail/mail.lmtp/Makefile.am
@@ -7,7 +7,8 @@ mail_lmtp_SOURCES+= $(top_srcdir)/usr.sbin/smtpd/log.c
 
 dist_man8_MANS =	$(top_srcdir)/usr.sbin/smtpd/mail.lmtp.8
 
-AM_CPPFLAGS=		-I$(top_srcdir)/usr.sbin/smtpd
+AM_CPPFLAGS=		-I$(top_srcdir)/usr.sbin/smtpd \
+			-I$(top_srcdir)/openbsd-compat
 
 LDADD = 		$(LIBOBJS)
 

--- a/mk/mail/mail.maildir/Makefile.am
+++ b/mk/mail/mail.maildir/Makefile.am
@@ -7,7 +7,8 @@ mail_maildir_SOURCES+= $(top_srcdir)/usr.sbin/smtpd/log.c
 
 dist_man8_MANS =	$(top_srcdir)/usr.sbin/smtpd/mail.maildir.8
 
-AM_CPPFLAGS=		-I$(top_srcdir)/usr.sbin/smtpd
+AM_CPPFLAGS=		-I$(top_srcdir)/usr.sbin/smtpd \
+			-I$(top_srcdir)/openbsd-compat
 
 LDADD = 		$(LIBOBJS)
 

--- a/mk/mail/mail.mboxfile/Makefile.am
+++ b/mk/mail/mail.mboxfile/Makefile.am
@@ -7,7 +7,8 @@ mail_mboxfile_SOURCES+= $(top_srcdir)/usr.sbin/smtpd/log.c
 
 dist_man8_MANS =	$(top_srcdir)/usr.sbin/smtpd/mail.mboxfile.8
 
-AM_CPPFLAGS=		-I$(top_srcdir)/usr.sbin/smtpd
+AM_CPPFLAGS=		-I$(top_srcdir)/usr.sbin/smtpd \
+			-I$(top_srcdir)/openbsd-compat
 
 LDADD = 		$(LIBOBJS)
 

--- a/mk/mail/mail.mda/Makefile.am
+++ b/mk/mail/mail.mda/Makefile.am
@@ -7,7 +7,8 @@ mail_mda_SOURCES+= $(top_srcdir)/usr.sbin/smtpd/log.c
 
 dist_man8_MANS =	$(top_srcdir)/usr.sbin/smtpd/mail.mda.8
 
-AM_CPPFLAGS=		-I$(top_srcdir)/usr.sbin/smtpd
+AM_CPPFLAGS=		-I$(top_srcdir)/usr.sbin/smtpd \
+			-I$(top_srcdir)/openbsd-compat
 
 LDADD = 		$(LIBOBJS)
 

--- a/mk/smtp/Makefile.am
+++ b/mk/smtp/Makefile.am
@@ -28,6 +28,8 @@ smtp_SOURCES+=	$(top_srcdir)/openbsd-compat/libtls/openssl.c
 
 AM_CPPFLAGS=		-DIO_TLS \
 			-I$(top_srcdir)/usr.sbin/smtpd \
+			-I$(top_srcdir)/openbsd-compat \
+			-I$(top_srcdir)/openbsd-compat/libtls \
 			-I$(srcdir) @CPPFLAGS@ $(PATHS) @DEFS@
 
 LDADD=			$(LIBOBJS)

--- a/mk/smtpctl/Makefile.am
+++ b/mk/smtpctl/Makefile.am
@@ -53,6 +53,7 @@ smtpctl_CPPFLAGS=	-DNO_IO -DCONFIG_MINIMUM \
 			-DPATH_GZCAT=\"$(ZCAT)\" \
 			-DPATH_ENCRYPT=\"$(pkglibexecdir)/encrypt\" \
 			-I$(top_srcdir)/usr.sbin/smtpd \
+			-I$(top_srcdir)/openbsd-compat \
 			-I$(srcdir) @CPPFLAGS@ $(PATHS) @DEFS@
 
 LDADD=			$(LIBOBJS)

--- a/mk/smtpd/Makefile.am
+++ b/mk/smtpd/Makefile.am
@@ -118,6 +118,8 @@ smtpd_SOURCES+=		$(top_srcdir)/openbsd-compat/libtls/openssl.c
 
 AM_CPPFLAGS=		-DIO_TLS \
 			-I$(top_srcdir)/usr.sbin/smtpd \
+			-I$(top_srcdir)/openbsd-compat \
+			-I$(top_srcdir)/openbsd-compat/libtls \
 			-I$(srcdir) $(PATHS) @DEFS@
 
 LDADD=			$(LIBOBJS) $(DB_LIB)


### PR DESCRIPTION
We might fail to compile the bundled libtls on some systems because --with-libevent adds to CFLAGS, so we end up using the system' tls.h instead of the bundled one.

Instead of the complete fix for the configure.ac, which is needed but there's not enough time for 7.6, move the -I flags to the various Makefile.am as AM_CPPFLAGS.