### PR TITLE
added missing openbsd-compat/openssl/posix_time.h

### DIFF
--- a/openbsd-compat/Makefile.am
+++ b/openbsd-compat/Makefile.am
@@ -13,6 +13,7 @@ EXTRA_DIST =	NOTES				\
 		libtls/tls.h			\
 		libtls/tls_internal.h		\
 		openbsd-compat.h		\
+		openssl/posix_time.h		\
 		paths_h/paths.h			\
 		sys/queue.h			\
 		sys/tree.h			\


### PR DESCRIPTION
Hey there, while trying to compile opensmtpd on debian I found that posix_time.h was missing. I couldn't find it in the release tarball of 7.6.0p0, so unless I did something completely wrong it might need to be added?