### PR TITLE
fix overly strict AUTH PLAIN pass check

### DIFF
--- a/usr.sbin/smtpd/smtp_session.c
+++ b/usr.sbin/smtpd/smtp_session.c
@@ -1980,7 +1980,7 @@ smtp_rfc4954_auth_plain(struct smtp_session *s, char *arg)
 			goto abort;
 
 		pass = memchr(user, '\0', len - (user - buf));
-		if (pass == NULL || pass >= buf + len - 2)
+		if (pass == NULL || pass >= buf + len - 1)
 			goto abort;
 		pass++; /* skip NUL */
 


### PR DESCRIPTION
While trying out OpenSMTPD, I found that `smtp_rfc4954_auth_plain` incorrectly rejects single character AUTH PLAIN passwords (which should be valid according to RFC 4616). Reason for this is the boundary check `pass >= buf + len - 2` being overly strict. This patch adjusts the condition to require only one byte after the second NUL.

The corresponding check for the username field remains unchanged, as it correctly requires space for both a username and a second NUL.