### PR TITLE
makemap: Print an error instead of exiting silently if not --with-table-db

### DIFF
--- a/usr.sbin/smtpd/smtpctl.c
+++ b/usr.sbin/smtpd/smtpctl.c
@@ -68,7 +68,9 @@
 #endif
 
 #ifndef HAVE_DB_API
-int makemap(int, int, char **) {
+int
+makemap(int prog_mode, int argc, char *argv[])
+{
 	errx(1, "makemap is non-functional when built without `./configure --with-table-db`");
 	return 1;
 }


### PR DESCRIPTION
exit(1) without a message saying why is confusing.