### PR TITLE
Add address to error log lines

### DIFF
--- a/usr.sbin/smtpd/smtp_session.c
+++ b/usr.sbin/smtpd/smtp_session.c
@@ -2174,33 +2174,40 @@ smtp_reply(struct smtp_session *s, char *fmt, ...)
 
 		if (s->flags & SF_BADINPUT) {
 			log_info("%016"PRIx64" smtp "
-			    "bad-input result=\"%.*s\"",
-			    s->id, n, buf);
+			    "bad-input "
+			    "addr=%s "
+			    "result=\"%.*s\"",
+			    s->id, ss_to_text(&s->ss), n, buf);
 		}
 		else if (s->state == STATE_AUTH_INIT) {
 			log_info("%016"PRIx64" smtp "
 			    "failed-command "
+			    "addr=%s "
 			    "command=\"AUTH PLAIN (...)\" result=\"%.*s\"",
-			    s->id, n, buf);
+			    s->id, ss_to_text(&s->ss), n, buf);
 		}
 		else if (s->state == STATE_AUTH_USERNAME) {
 			log_info("%016"PRIx64" smtp "
 			    "failed-command "
+			    "addr=%s "
 			    "command=\"AUTH LOGIN (username)\" result=\"%.*s\"",
-			    s->id, n, buf);
+			    s->id, ss_to_text(&s->ss), n, buf);
 		}
 		else if (s->state == STATE_AUTH_PASSWORD) {
 			log_info("%016"PRIx64" smtp "
 			    "failed-command "
+			    "addr=%s "
 			    "command=\"AUTH LOGIN (password)\" result=\"%.*s\"",
-			    s->id, n, buf);
+			    s->id, ss_to_text(&s->ss), n, buf);
 		}
 		else {
 			strnvis(tmp, s->cmd, sizeof tmp, VIS_SAFE | VIS_CSTYLE);
 			log_info("%016"PRIx64" smtp "
-			    "failed-command command=\"%s\" "
+			    "failed-command "
+			    "addr=%s "
+			    "command=\"%s\" "
 			    "result=\"%.*s\"",
-			    s->id, tmp, n, buf);
+			    s->id, ss_to_text(&s->ss), tmp, n, buf);
 		}
 		break;
 	}


### PR DESCRIPTION
This comes from my trying to have sshguard work with OpenSMTPD.

The parser in sshguard hasn't been upgraded to the new log format [1], the reason being that the new format is split into multiple lines [2], which makes it hard for a stateless tool to correlate a source to a failure.

My quickly hacked solution [3] is an awk script to keep track of the address of each session and emit an old-style log, but of course it's lame.

Here, I'm proposing to add the addr= field to failed-command and bad-input log lines, which will make it trivial to upgrade sshguard's parser.

[1] https://bitbucket.org/sshguard/sshguard/src/305933b2e42e407391cf5a663e876138886f6fc1/src/parser/attack_scanner.l#lines-303:308
[2] https://sourceforge.net/p/sshguard/mailman/sshguard-users/thread/42d11423-0c81-0cb0-87cc-065c1e6bc8ea%40gmail.com/
[3] https://sourceforge.net/p/sshguard/mailman/message/59305119/