### PR TITLE
Fix shared dispatcher TLS config mutation in mta_tls_init

### DIFF
--- a/usr.sbin/smtpd/mta.c
+++ b/usr.sbin/smtpd/mta.c
@@ -60,7 +60,6 @@
 #define RELAY_ONHOLD		0x01
 #define RELAY_HOLDQ		0x02
 
-static void mta_setup_dispatcher(struct dispatcher *);
 static void mta_handle_envelope(struct envelope *, const char *);
 static void mta_query_smarthost(struct envelope *);
 static void mta_on_smarthost(struct envelope *, const char *);
@@ -473,15 +472,6 @@ mta_imsg(struct mproc *p, struct imsg *imsg)
 void
 mta_postfork(void)
 {
-	struct dispatcher *dispatcher;
-	const char *key;
-	void *iter;
-
-	iter = NULL;
-	while (dict_iter(env->sc_dispatchers, &iter, &key, (void **)&dispatcher)) {
-		log_debug("%s: %s", __func__, key);
-		mta_setup_dispatcher(dispatcher);
-	}
 }
 
 struct tls_config *
@@ -546,18 +536,6 @@ mta_tls_config_create(struct dispatcher_remote *remote, int verify)
 	}
 
 	return (config);
-}
-
-static void
-mta_setup_dispatcher(struct dispatcher *dispatcher)
-{
-	struct dispatcher_remote *remote;
-
-	if (dispatcher->type != DISPATCHER_REMOTE)
-		return;
-
-	remote = &dispatcher->u.remote;
-	remote->tls_config = mta_tls_config_create(remote, remote->tls_verify);
 }
 
 void

--- a/usr.sbin/smtpd/mta.c
+++ b/usr.sbin/smtpd/mta.c
@@ -484,21 +484,15 @@ mta_postfork(void)
 	}
 }
 
-static void
-mta_setup_dispatcher(struct dispatcher *dispatcher)
+struct tls_config *
+mta_tls_config_create(struct dispatcher_remote *remote, int verify)
 {
-	struct dispatcher_remote *remote;
 	static const char *dheparams[] = { "none", "auto", "legacy" };
 	struct tls_config *config;
 	struct pki *pki;
 	struct ca *ca;
 	const char *ciphers;
 	uint32_t protos;
-
-	if (dispatcher->type != DISPATCHER_REMOTE)
-		return;
-
-	remote = &dispatcher->u.remote;
 
 	if ((config = tls_config_new()) == NULL)
 		fatal("smtpd: tls_config_new");
@@ -543,7 +537,7 @@ mta_setup_dispatcher(struct dispatcher *dispatcher)
 		fatalx("tls_config_set_ca_file: %s",
 		    tls_config_error(config));
 
-	if (remote->tls_verify) {
+	if (verify) {
 		tls_config_verify(config);
 	} else {
 		tls_config_insecure_noverifycert(config);
@@ -551,7 +545,19 @@ mta_setup_dispatcher(struct dispatcher *dispatcher)
 		tls_config_insecure_noverifytime(config);
 	}
 
-	remote->tls_config = config;
+	return (config);
+}
+
+static void
+mta_setup_dispatcher(struct dispatcher *dispatcher)
+{
+	struct dispatcher_remote *remote;
+
+	if (dispatcher->type != DISPATCHER_REMOTE)
+		return;
+
+	remote = &dispatcher->u.remote;
+	remote->tls_config = mta_tls_config_create(remote, remote->tls_verify);
 }
 
 void

--- a/usr.sbin/smtpd/mta.c
+++ b/usr.sbin/smtpd/mta.c
@@ -522,10 +522,14 @@ mta_tls_config_create(struct dispatcher_remote *remote, int verify)
 			fatalx("tls_config_set_ca_mem: %s",
 			    tls_config_error(config));
 	}
-	else if (tls_config_set_ca_file(config, tls_default_ca_cert_file())
-	    == -1)
-		fatalx("tls_config_set_ca_file: %s",
-		    tls_config_error(config));
+	else {
+		if (env->sc_default_ca_cert == NULL)
+			fatalx("default CA certificate not available");
+		if (tls_config_set_ca_mem(config, env->sc_default_ca_cert,
+		    env->sc_default_ca_cert_len) == -1)
+			fatalx("tls_config_set_ca_mem: %s",
+			    tls_config_error(config));
+	}
 
 	if (verify) {
 		tls_config_verify(config);

--- a/usr.sbin/smtpd/mta_session.c
+++ b/usr.sbin/smtpd/mta_session.c
@@ -1233,7 +1233,9 @@ mta_io(struct io *io, int evt, void *arg)
 		log_info("%016"PRIx64" mta tls ciphers=%s",
 		    s->id, tls_to_text(io_tls(s->io)));
 		s->flags |= MTA_TLS;
-		if (s->relay->dispatcher->u.remote.tls_verify)
+		if (s->relay->dispatcher->u.remote.tls_verify ||
+		    ((s->flags & MTA_WANT_SECURE) &&
+		    !s->relay->dispatcher->u.remote.tls_required))
 			s->flags |= MTA_TLS_VERIFIED;
 
 		mta_tls_started(s);
@@ -1574,6 +1576,7 @@ static void
 mta_tls_init(struct mta_session *s)
 {
 	struct dispatcher_remote *remote;
+	struct tls_config *config;
 	struct tls *tls;
 
 	if ((tls = tls_client()) == NULL) {
@@ -1584,17 +1587,27 @@ mta_tls_init(struct mta_session *s)
 
 	remote = &s->relay->dispatcher->u.remote;
 	if ((s->flags & MTA_WANT_SECURE) && !remote->tls_required) {
-		/* If TLS not explicitly configured, use implicit config. */
-		remote->tls_required = 1;
-		remote->tls_verify = 1;
-		tls_config_verify(remote->tls_config);
-	}
-	if (tls_configure(tls, remote->tls_config) == -1) {
+		/*
+		 * TLS not explicitly configured but required by relay
+		 * URL. Create a session-local config with verification
+		 * enabled instead of mutating the shared dispatcher
+		 * config.
+		 */
+		config = mta_tls_config_create(remote, 1);
+	} else
+		config = remote->tls_config;
+
+	if (tls_configure(tls, config) == -1) {
 		log_info("%016"PRIx64" mta closing reason=tls-failure", s->id);
 		tls_free(tls);
+		if (config != remote->tls_config)
+			tls_config_free(config);
 		s->flags |= MTA_FREE;
 		return;
 	}
+
+	if (config != remote->tls_config)
+		tls_config_free(config);
 
 	if (io_connect_tls(s->io, tls, s->mxname) == -1) {
 		log_info("%016"PRIx64" mta closing reason=tls-connect-failed", s->id);

--- a/usr.sbin/smtpd/mta_session.c
+++ b/usr.sbin/smtpd/mta_session.c
@@ -1586,28 +1586,19 @@ mta_tls_init(struct mta_session *s)
 	}
 
 	remote = &s->relay->dispatcher->u.remote;
-	if ((s->flags & MTA_WANT_SECURE) && !remote->tls_required) {
-		/*
-		 * TLS not explicitly configured but required by relay
-		 * URL. Create a session-local config with verification
-		 * enabled instead of mutating the shared dispatcher
-		 * config.
-		 */
-		config = mta_tls_config_create(remote, 1);
-	} else
-		config = remote->tls_config;
+	config = mta_tls_config_create(remote,
+	    remote->tls_verify ||
+	    ((s->flags & MTA_WANT_SECURE) && !remote->tls_required));
 
 	if (tls_configure(tls, config) == -1) {
 		log_info("%016"PRIx64" mta closing reason=tls-failure", s->id);
 		tls_free(tls);
-		if (config != remote->tls_config)
-			tls_config_free(config);
+		tls_config_free(config);
 		s->flags |= MTA_FREE;
 		return;
 	}
 
-	if (config != remote->tls_config)
-		tls_config_free(config);
+	tls_config_free(config);
 
 	if (io_connect_tls(s->io, tls, s->mxname) == -1) {
 		log_info("%016"PRIx64" mta closing reason=tls-connect-failed", s->id);

--- a/usr.sbin/smtpd/smtpd.c
+++ b/usr.sbin/smtpd/smtpd.c
@@ -1196,6 +1196,9 @@ load_pki_tree(void)
 		if (!ssl_load_cafile(sca, sca->ca_cert_file))
 			fatalx("load_pki_tree: failed to load CA file");
 	}
+
+	env->sc_default_ca_cert = tls_load_file(tls_default_ca_cert_file(),
+	    &env->sc_default_ca_cert_len, NULL);
 }
 
 void

--- a/usr.sbin/smtpd/smtpd.h
+++ b/usr.sbin/smtpd/smtpd.h
@@ -1203,7 +1203,6 @@ struct dispatcher_remote {
 
 	char	*source;
 
-	struct tls_config *tls_config;
 	char	*ca;
 	char	*pki;
 

--- a/usr.sbin/smtpd/smtpd.h
+++ b/usr.sbin/smtpd/smtpd.h
@@ -1514,6 +1514,7 @@ void m_clear_params(struct dict *);
 
 
 /* mta.c */
+struct tls_config *mta_tls_config_create(struct dispatcher_remote *, int);
 void mta_postfork(void);
 void mta_postprivdrop(void);
 void mta_imsg(struct mproc *, struct imsg *);

--- a/usr.sbin/smtpd/smtpd.h
+++ b/usr.sbin/smtpd/smtpd.h
@@ -634,6 +634,8 @@ struct smtpd {
 	struct dispatcher			*sc_dispatcher_bounce;
 
 	struct dict			       *sc_ca_dict;
+	uint8_t				       *sc_default_ca_cert;
+	size_t				        sc_default_ca_cert_len;
 	struct dict			       *sc_pki_dict;
 	struct dict			       *sc_ssl_dict;
 


### PR DESCRIPTION
When a relay used smtp+tls:// or smtps:// without explicit TLS configuration on the dispatcher, mta_tls_init() mutated the shared dispatcher_remote struct (tls_required, tls_verify, and tls_config). Since all relays using the same action share a single dispatcher, this permanently altered TLS behavior for subsequent sessions: smtp+notls:// relays would be wrongly rejected, and opportunistic TLS sessions would unexpectedly require certificate verification.

Fix by creating a session-local tls_config with verification enabled instead of mutating the shared one. Extract tls_config creation into a reusable mta_tls_config_create() helper called from both mta_setup_dispatcher() and mta_tls_init(). The session-local config is freed after tls_configure() which holds its own refcounted reference.